### PR TITLE
Add failing tests with snapshots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,19 @@ if(UNIX)
 endif()
 
 # Tests
-add_executable(tests
+set(TEST_SRC
     tests/disabled_tests.c
     tests/float_tests.c
     tests/integer_tests.c
     tests/string_tests.c
     tests/wildcard_match_tests.c
 )
+add_executable(tests ${TEST_SRC})
 target_include_directories(tests PUBLIC include)
 target_link_libraries(tests PUBLIC ${PROJECT_NAME})
+
+add_executable(failing_tests ${TEST_SRC})
+target_include_directories(failing_tests PUBLIC include)
+target_link_libraries(failing_tests PUBLIC ${PROJECT_NAME})
+target_compile_definitions(failing_tests PRIVATE RKTEST_FAILING_TESTS=1)
+

--- a/include/rktest/rktest.h
+++ b/include/rktest/rktest.h
@@ -214,78 +214,90 @@ int rktest_strcasecmp(const char* lhs, const char* rhs);
 bool rktest_floats_within_4_ulp(float lhs, float rhs);
 bool rktest_doubles_within_4_ulp(double lhs, double rhs);
 
-#define RKTEST_CHECK_BOOL(actual, expected, is_assert, ...)                          \
-	do {                                                                             \
-		const bool actual_val = actual;                                              \
-		const bool expected_val = expected;                                          \
-		if (actual_val != expected_val) {                                            \
-			printf("%s(%d): error: Value of: `%s`:\n", __FILE__, __LINE__, #actual); \
-			printf("  Actual: %s\n", actual_val ? "true" : "false");                 \
-			printf("Expected: %s\n", expected_val ? "true" : "false");               \
-			printf(__VA_ARGS__);                                                     \
-			printf("\n");                                                            \
-			rktest_fail_current_test();                                              \
-			if (is_assert) {                                                         \
-				return;                                                              \
-			}                                                                        \
-		}                                                                            \
+#define RKTEST_CHECK_BOOL(actual, expected, is_assert, ...)            \
+	do {                                                               \
+		const bool actual_val = actual;                                \
+		const bool expected_val = expected;                            \
+		if (actual_val != expected_val) {                              \
+			if (rktest_filenames_enabled()) {                          \
+				printf("%s(%d): ", __FILE__, __LINE__);                \
+			}                                                          \
+			printf("error: Value of: `%s`:\n", #actual);               \
+			printf("  Actual: %s\n", actual_val ? "true" : "false");   \
+			printf("Expected: %s\n", expected_val ? "true" : "false"); \
+			printf(__VA_ARGS__);                                       \
+			printf("\n");                                              \
+			rktest_fail_current_test();                                \
+			if (is_assert) {                                           \
+				return;                                                \
+			}                                                          \
+		}                                                              \
 	} while (0)
 
-#define RKTEST_CHECK_EQ(type, fmt, lhs, rhs, is_assert, ...)                                   \
-	do {                                                                                       \
-		const type lhs_val = lhs;                                                              \
-		const type rhs_val = rhs;                                                              \
-		if (lhs_val != rhs_val) {                                                              \
-			printf("%s(%d): error: Expected equality of these values:\n", __FILE__, __LINE__); \
-			printf("  %s\n", #lhs);                                                            \
-			const bool lhs_is_literal = rktest_string_is_number(#lhs);                         \
-			if (!lhs_is_literal)                                                               \
-				printf("    Which is: " fmt "\n", lhs_val);                                    \
-			printf("  %s\n", #rhs);                                                            \
-			const bool rhs_is_literal = rktest_string_is_number(#rhs);                         \
-			if (!rhs_is_literal)                                                               \
-				printf("    Which is: " fmt "\n", rhs_val);                                    \
-			printf(__VA_ARGS__);                                                               \
-			printf("\n");                                                                      \
-			rktest_fail_current_test();                                                        \
-			if (is_assert) {                                                                   \
-				return;                                                                        \
-			}                                                                                  \
-		}                                                                                      \
+#define RKTEST_CHECK_EQ(type, fmt, lhs, rhs, is_assert, ...)           \
+	do {                                                               \
+		const type lhs_val = lhs;                                      \
+		const type rhs_val = rhs;                                      \
+		if (lhs_val != rhs_val) {                                      \
+			if (rktest_filenames_enabled()) {                          \
+				printf("%s(%d): ", __FILE__, __LINE__);                \
+			}                                                          \
+			printf("error: Expected equality of these values:\n");     \
+			printf("  %s\n", #lhs);                                    \
+			const bool lhs_is_literal = rktest_string_is_number(#lhs); \
+			if (!lhs_is_literal)                                       \
+				printf("    Which is: " fmt "\n", lhs_val);            \
+			printf("  %s\n", #rhs);                                    \
+			const bool rhs_is_literal = rktest_string_is_number(#rhs); \
+			if (!rhs_is_literal)                                       \
+				printf("    Which is: " fmt "\n", rhs_val);            \
+			printf(__VA_ARGS__);                                       \
+			printf("\n");                                              \
+			rktest_fail_current_test();                                \
+			if (is_assert) {                                           \
+				return;                                                \
+			}                                                          \
+		}                                                              \
 	} while (0)
 
-#define RKTEST_CHECK_CMP(type, fmt, lhs, rhs, op, is_assert, ...)                                                                                \
-	do {                                                                                                                                         \
-		const type lhs_val = lhs;                                                                                                                \
-		const type rhs_val = rhs;                                                                                                                \
-		if (!(lhs_val op rhs_val)) {                                                                                                             \
-			printf("%s(%d): error: Expected (%s) %s (%s), actual: " fmt " vs " fmt "\n", __FILE__, __LINE__, #lhs, #op, #rhs, lhs_val, rhs_val); \
-			printf(__VA_ARGS__);                                                                                                                 \
-			printf("\n");                                                                                                                        \
-			rktest_fail_current_test();                                                                                                          \
-			if (is_assert) {                                                                                                                     \
-				return;                                                                                                                          \
-			}                                                                                                                                    \
-		}                                                                                                                                        \
+#define RKTEST_CHECK_CMP(type, fmt, lhs, rhs, op, is_assert, ...)                                                    \
+	do {                                                                                                             \
+		const type lhs_val = lhs;                                                                                    \
+		const type rhs_val = rhs;                                                                                    \
+		if (!(lhs_val op rhs_val)) {                                                                                 \
+			if (rktest_filenames_enabled()) {                                                                        \
+				printf("%s(%d): ", __FILE__, __LINE__);                                                              \
+			}                                                                                                        \
+			printf("error: Expected (%s) %s (%s), actual: " fmt " vs " fmt "\n", #lhs, #op, #rhs, lhs_val, rhs_val); \
+			printf(__VA_ARGS__);                                                                                     \
+			printf("\n");                                                                                            \
+			rktest_fail_current_test();                                                                              \
+			if (is_assert) {                                                                                         \
+				return;                                                                                              \
+			}                                                                                                        \
+		}                                                                                                            \
 	} while (0)
 
-#define RKTEST_CHECK_FLOAT_EQ(type, lhs, rhs, compare, is_assert, ...)                         \
-	do {                                                                                       \
-		const type lhs_val = lhs;                                                              \
-		const type rhs_val = rhs;                                                              \
-		if (!compare(lhs_val, rhs_val)) {                                                      \
-			printf("%s(%d): error: Expected equality of these values:\n", __FILE__, __LINE__); \
-			printf("  %s\n", #lhs);                                                            \
-			printf("    Which is: %.8f\n", lhs_val);                                           \
-			printf("  %s\n", #rhs);                                                            \
-			printf("    Which is: %.8f\n", rhs_val);                                           \
-			printf(__VA_ARGS__);                                                               \
-			printf("\n");                                                                      \
-			rktest_fail_current_test();                                                        \
-			if (is_assert) {                                                                   \
-				return;                                                                        \
-			}                                                                                  \
-		}                                                                                      \
+#define RKTEST_CHECK_FLOAT_EQ(type, lhs, rhs, compare, is_assert, ...) \
+	do {                                                               \
+		const type lhs_val = lhs;                                      \
+		const type rhs_val = rhs;                                      \
+		if (!compare(lhs_val, rhs_val)) {                              \
+			if (rktest_filenames_enabled()) {                          \
+				printf("%s(%d): ", __FILE__, __LINE__);                \
+			}                                                          \
+			printf("error: Expected equality of these values:\n");     \
+			printf("  %s\n", #lhs);                                    \
+			printf("    Which is: %.8f\n", lhs_val);                   \
+			printf("  %s\n", #rhs);                                    \
+			printf("    Which is: %.8f\n", rhs_val);                   \
+			printf(__VA_ARGS__);                                       \
+			printf("\n");                                              \
+			rktest_fail_current_test();                                \
+			if (is_assert) {                                           \
+				return;                                                \
+			}                                                          \
+		}                                                              \
 	} while (0)
 
 #define RKTEST_CHECK_STREQ(lhs, rhs, is_assert, match_case, ...)                                         \
@@ -293,7 +305,10 @@ bool rktest_doubles_within_4_ulp(double lhs, double rhs);
 		const char* lhs_val = lhs;                                                                       \
 		const char* rhs_val = rhs;                                                                       \
 		if (match_case ? (strcmp(lhs_val, rhs_val) != 0) : (rktest_strcasecmp(lhs_val, rhs_val) != 0)) { \
-			printf("%s(%d): error: Expected equality of these values:\n", __FILE__, __LINE__);           \
+			if (rktest_filenames_enabled()) {                                                            \
+				printf("%s(%d): ", __FILE__, __LINE__);                                                  \
+			}                                                                                            \
+			printf("error: Expected equality of these values:\n");                                       \
 			printf("  %s\n", #lhs);                                                                      \
 			const bool lhs_is_literal = (#lhs)[0] == '"';                                                \
 			if (!lhs_is_literal)                                                                         \
@@ -318,7 +333,10 @@ bool rktest_doubles_within_4_ulp(double lhs, double rhs);
 		const char* lhs_val = lhs;                                                                       \
 		const char* rhs_val = rhs;                                                                       \
 		if (match_case ? (strcmp(lhs_val, rhs_val) == 0) : (rktest_strcasecmp(lhs_val, rhs_val) == 0)) { \
-			printf("%s(%d): error: Expected (%s) != (%s)", __FILE__, __LINE__, #lhs, #rhs);              \
+			if (rktest_filenames_enabled()) {                                                            \
+				printf("%s(%d): ", __FILE__, __LINE__);                                                  \
+			}                                                                                            \
+			printf("error: Expected (%s) != (%s)", #lhs, #rhs);                                          \
 			if (!match_case)                                                                             \
 				printf(" (ignoring case)");                                                              \
 			printf(", actual: \"%s\" vs \"%s\"\n", lhs_val, rhs_val);                                    \
@@ -333,6 +351,7 @@ bool rktest_doubles_within_4_ulp(double lhs, double rhs);
 
 /* Logging */
 bool rktest_colors_enabled(void);
+bool rktest_filenames_enabled(void);
 
 #define RKTEST_COLOR_GREEN (rktest_colors_enabled() ? "\033[32m" : "")
 #define RKTEST_COLOR_RED (rktest_colors_enabled() ? "\033[31m" : "")

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -569,7 +569,7 @@ static void print_failed_tests(rktest_report_t* report) {
 		rktest_log_error("[  FAILED  ] ", "%s.%s\n", failed_test->suite_name, failed_test->test_name);
 	}
 	printf("\n");
-	printf(" %zu FAILED TEST%s\n", report->num_failed_tests, report->num_failed_tests > 1 ? "s" : "");
+	printf(" %zu FAILED TEST%s\n", report->num_failed_tests, report->num_failed_tests > 1 ? "S" : "");
 }
 
 int rktest_main(int argc, const char* argv[]) {
@@ -604,7 +604,7 @@ int rktest_main(int argc, const char* argv[]) {
 		if (!tests_failed) {
 			printf("\n");
 		}
-		rktest_printf_yellow("  YOU HAVE %zu DISABLED TEST%s\n", env->total_num_disabled_tests, env->total_num_disabled_tests > 1 ? "s" : "");
+		rktest_printf_yellow("  YOU HAVE %zu DISABLED TEST%s\n", env->total_num_disabled_tests, env->total_num_disabled_tests > 1 ? "S" : "");
 	}
 
 	free(report);

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -69,7 +69,7 @@ typedef enum {
 typedef struct {
 	rktest_color_mode_t color_mode;
 	char test_filter[RKTEST_MAX_FILTER_LENGTH];
-	bool print_timestamp_enabled;
+	bool print_timestamps_enabled;
 } rktest_config_t;
 
 typedef struct {
@@ -230,9 +230,14 @@ __attribute__((used, section("rktest"))) const rktest_test_t* const dummy = NULL
 /* -------------------- Header function implementations -------------------- */
 static bool g_colors_enabled = false;
 static bool g_current_test_failed = false;
+static bool g_filenames_enabled = true;
 
 bool rktest_colors_enabled(void) {
 	return g_colors_enabled;
+}
+
+bool rktest_filenames_enabled(void) {
+	return g_filenames_enabled;
 }
 
 void rktest_fail_current_test(void) {
@@ -301,7 +306,7 @@ static void print_usage(void) {
 static rktest_config_t parse_args(int argc, const char* argv[]) {
 	rktest_config_t config = (rktest_config_t) { 0 };
 	config.color_mode = RKTEST_COLOR_MODE_AUTO;
-	config.print_timestamp_enabled = true;
+	config.print_timestamps_enabled = true;
 
 	for (int i = 1; i < argc; i++) {
 		const char* arg = argv[i];
@@ -333,9 +338,17 @@ static rktest_config_t parse_args(int argc, const char* argv[]) {
 
 		else if (string_starts_with(arg, "--rktest_print_time=")) {
 			if (strcmp(arg + strlen("--rktest_print_time="), "0") == 0) {
-				config.print_timestamp_enabled = false;
+				config.print_timestamps_enabled = false;
 			} else {
-				config.print_timestamp_enabled = true;
+				config.print_timestamps_enabled = true;
+			}
+		}
+
+		else if (string_starts_with(arg, "--rktest_print_filenames=")) {
+			if (strcmp(arg + strlen("--rktest_print_filenames="), "0") == 0) {
+				g_filenames_enabled = false;
+			} else {
+				g_filenames_enabled = true;
 			}
 		}
 
@@ -509,7 +522,7 @@ static bool run_test(const rktest_test_t* test, const rktest_config_t* config) {
 		rktest_printf_red("[  FAILED  ] ");
 	}
 	printf("%s.%s ", test->suite_name, test->test_name);
-	if (config->print_timestamp_enabled) {
+	if (config->print_timestamps_enabled) {
 		printf("(%d ms)", test_time_ms);
 	}
 	printf("\n");
@@ -554,7 +567,7 @@ static rktest_report_t* run_all_tests(rktest_environment_t* env, const rktest_co
 		}
 		rktest_millis_t suite_time_ms = rktest_timer_stop(&suite_timer);
 		rktest_log_info("[----------] ", "%zu tests from %s ", num_filtered_tests, suite->name);
-		if (config->print_timestamp_enabled) {
+		if (config->print_timestamps_enabled) {
 			printf("(%d ms total)", suite_time_ms);
 		}
 		printf("\n\n");
@@ -589,7 +602,7 @@ int rktest_main(int argc, const char* argv[]) {
 
 	rktest_log_info("[----------] ", "Global test environment tear-down.\n");
 	rktest_log_info("[==========] ", "%zu tests from %zu test suites ran. ", env->total_num_filtered_tests, env->total_num_filtered_suites);
-	if (config.print_timestamp_enabled) {
+	if (config.print_timestamps_enabled) {
 		printf("(%d ms total)", total_time_ms);
 	}
 	printf("\n");

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -212,7 +212,7 @@
   [  FAILED  ] string_tests.strings_case_equal_info
   
    21 FAILED TESTS
-    YOU HAVE 2 DISABLED TESTS
+    YOU HAVE 3 DISABLED TESTS
   
   '''
 # ---
@@ -313,7 +313,7 @@
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 36 tests.
   
-    YOU HAVE 2 DISABLED TESTS
+    YOU HAVE 3 DISABLED TESTS
   
   '''
 # ---
@@ -413,7 +413,7 @@
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 36 tests.
   
-    YOU HAVE 2 DISABLED TESTS
+    YOU HAVE 3 DISABLED TESTS
   
   '''
 # ---
@@ -600,7 +600,7 @@
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 36 tests.
   
-    YOU HAVE 2 DISABLED TESTS
+    YOU HAVE 3 DISABLED TESTS
   
   '''
 # ---

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_failing_tests
   '''
-  [==========] Running 30 tests from 5 test suites.
+  [==========] Running 32 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -9,12 +9,42 @@
   [       OK ] disabled_tests.this_test_should_run 
   [----------] 1 tests from disabled_tests 
   
-  [----------] 2 tests from float_tests
+  [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
-  [       OK ] float_tests.float_equal 
+  D:\dev\c\rktest\tests\float_tests.c(12): error: Expected equality of these values:
+    float_sum
+      Which is: 1.00000000
+    0.9f
+      Which is: 0.89999998
+   
+  [  FAILED  ] float_tests.float_equal 
+  [ RUN      ] float_tests.float_equal_info 
+  D:\dev\c\rktest\tests\float_tests.c(17): error: Expected equality of these values:
+    float_sum
+      Which is: 1.00000000
+    0.9f
+      Which is: 0.89999998
+  Hello world!
+  
+  [  FAILED  ] float_tests.float_equal_info 
   [ RUN      ] float_tests.double_equal 
-  [       OK ] float_tests.double_equal 
-  [----------] 2 tests from float_tests 
+  D:\dev\c\rktest\tests\float_tests.c(22): error: Expected equality of these values:
+    double_sum
+      Which is: 1.00000000
+    0.9
+      Which is: 0.90000000
+   
+  [  FAILED  ] float_tests.double_equal 
+  [ RUN      ] float_tests.double_equal_info 
+  D:\dev\c\rktest\tests\float_tests.c(27): error: Expected equality of these values:
+    double_sum
+      Which is: 1.00000000
+    0.9
+      Which is: 0.90000000
+  Hello world!
+  
+  [  FAILED  ] float_tests.double_equal_info 
+  [----------] 4 tests from float_tests 
   
   [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
@@ -124,9 +154,13 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 30 tests from 5 test suites ran. 
-  [  PASSED  ] 17 tests.
-  [  FAILED  ] 13 tests, listed below:
+  [==========] 32 tests from 5 test suites ran. 
+  [  PASSED  ] 15 tests.
+  [  FAILED  ] 17 tests, listed below:
+  [  FAILED  ] float_tests.float_equal
+  [  FAILED  ] float_tests.float_equal_info
+  [  FAILED  ] float_tests.double_equal
+  [  FAILED  ] float_tests.double_equal_info
   [  FAILED  ] integer_tests.expect_true
   [  FAILED  ] integer_tests.expect_true_info
   [  FAILED  ] integer_tests.expect_false
@@ -141,7 +175,7 @@
   [  FAILED  ] integer_tests.expect_greater_than_equal
   [  FAILED  ] integer_tests.expect_greater_than_equal_info
   
-   13 FAILED TESTs
+   17 FAILED TESTs
     YOU HAVE 1 DISABLED TEST
   
   '''
@@ -149,7 +183,7 @@
 # name: test_infix_match
   '''
   Note: Test filter = *tests*
-  [==========] Running 30 tests from 5 test suites.
+  [==========] Running 32 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -157,12 +191,16 @@
   [       OK ] disabled_tests.this_test_should_run 
   [----------] 1 tests from disabled_tests 
   
-  [----------] 2 tests from float_tests
+  [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
+  [ RUN      ] float_tests.float_equal_info 
+  [       OK ] float_tests.float_equal_info 
   [ RUN      ] float_tests.double_equal 
   [       OK ] float_tests.double_equal 
-  [----------] 2 tests from float_tests 
+  [ RUN      ] float_tests.double_equal_info 
+  [       OK ] float_tests.double_equal_info 
+  [----------] 4 tests from float_tests 
   
   [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
@@ -228,8 +266,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 30 tests from 5 test suites ran. 
-  [  PASSED  ] 30 tests.
+  [==========] 32 tests from 5 test suites ran. 
+  [  PASSED  ] 32 tests.
   
     YOU HAVE 1 DISABLED TEST
   
@@ -237,7 +275,7 @@
 # ---
 # name: test_no_args
   '''
-  [==========] Running 30 tests from 5 test suites.
+  [==========] Running 32 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -245,12 +283,16 @@
   [       OK ] disabled_tests.this_test_should_run 
   [----------] 1 tests from disabled_tests 
   
-  [----------] 2 tests from float_tests
+  [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
+  [ RUN      ] float_tests.float_equal_info 
+  [       OK ] float_tests.float_equal_info 
   [ RUN      ] float_tests.double_equal 
   [       OK ] float_tests.double_equal 
-  [----------] 2 tests from float_tests 
+  [ RUN      ] float_tests.double_equal_info 
+  [       OK ] float_tests.double_equal_info 
+  [----------] 4 tests from float_tests 
   
   [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
@@ -316,8 +358,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 30 tests from 5 test suites ran. 
-  [  PASSED  ] 30 tests.
+  [==========] 32 tests from 5 test suites ran. 
+  [  PASSED  ] 32 tests.
   
     YOU HAVE 1 DISABLED TEST
   
@@ -412,7 +454,7 @@
 # name: test_wildcard_match
   '''
   Note: Test filter = *
-  [==========] Running 30 tests from 5 test suites.
+  [==========] Running 32 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -420,12 +462,16 @@
   [       OK ] disabled_tests.this_test_should_run 
   [----------] 1 tests from disabled_tests 
   
-  [----------] 2 tests from float_tests
+  [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
+  [ RUN      ] float_tests.float_equal_info 
+  [       OK ] float_tests.float_equal_info 
   [ RUN      ] float_tests.double_equal 
   [       OK ] float_tests.double_equal 
-  [----------] 2 tests from float_tests 
+  [ RUN      ] float_tests.double_equal_info 
+  [       OK ] float_tests.double_equal_info 
+  [----------] 4 tests from float_tests 
   
   [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
@@ -491,8 +537,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 30 tests from 5 test suites ran. 
-  [  PASSED  ] 30 tests.
+  [==========] 32 tests from 5 test suites ran. 
+  [  PASSED  ] 32 tests.
   
     YOU HAVE 1 DISABLED TEST
   

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -1,8 +1,7 @@
 # serializer version: 1
-# name: test_infix_match
+# name: test_failing_tests
   '''
-  Note: Test filter = *tests*
-  [==========] Running 22 tests from 5 test suites.
+  [==========] Running 30 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -17,24 +16,84 @@
   [       OK ] float_tests.double_equal 
   [----------] 2 tests from float_tests 
   
-  [----------] 8 tests from integer_tests
+  [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
-  [       OK ] integer_tests.expect_true 
+  D:\dev\c\rktest\tests\integer_tests.c(23): error: Value of: `int_sum1 == 3`:
+    Actual: false
+  Expected: true
+   
+  [  FAILED  ] integer_tests.expect_true 
+  [ RUN      ] integer_tests.expect_true_info 
+  D:\dev\c\rktest\tests\integer_tests.c(28): error: Value of: `int_sum2 == 7`:
+    Actual: false
+  Expected: true
+  int_sum2 = 17
+  
+  [  FAILED  ] integer_tests.expect_true_info 
   [ RUN      ] integer_tests.expect_false 
-  [       OK ] integer_tests.expect_false 
+  D:\dev\c\rktest\tests\integer_tests.c(33): error: Value of: `int_sum1 == 1 + 2 + 50`:
+    Actual: true
+  Expected: false
+   
+  [  FAILED  ] integer_tests.expect_false 
+  [ RUN      ] integer_tests.expect_false_info 
+  [       OK ] integer_tests.expect_false_info 
   [ RUN      ] integer_tests.expect_equal 
-  [       OK ] integer_tests.expect_equal 
+  D:\dev\c\rktest\tests\integer_tests.c(44): error: Expected equality of these values:
+    int_sum1
+      Which is: 53
+    3
+   
+  [  FAILED  ] integer_tests.expect_equal 
+  [ RUN      ] integer_tests.expect_equal_info 
+  D:\dev\c\rktest\tests\integer_tests.c(54): error: Expected equality of these values:
+    int_sum2
+      Which is: 17
+    7
+  int_sum2 = 17
+  
+  [  FAILED  ] integer_tests.expect_equal_info 
   [ RUN      ] integer_tests.expect_not_equal 
   [       OK ] integer_tests.expect_not_equal 
+  [ RUN      ] integer_tests.expect_not_equal_info 
+  [       OK ] integer_tests.expect_not_equal_info 
   [ RUN      ] integer_tests.expect_less_than 
-  [       OK ] integer_tests.expect_less_than 
+  D:\dev\c\rktest\tests\integer_tests.c(85): error: Expected (int_sum1) < (int_sum2), actual: 53 vs 17
+   
+  [  FAILED  ] integer_tests.expect_less_than 
+  [ RUN      ] integer_tests.expect_less_than_info 
+  D:\dev\c\rktest\tests\integer_tests.c(95): error: Expected (int_sum1) < (int_sum2), actual: 53 vs 17
+  int_sum2 = 17
+  
+  [  FAILED  ] integer_tests.expect_less_than_info 
   [ RUN      ] integer_tests.expect_less_than_equal 
-  [       OK ] integer_tests.expect_less_than_equal 
+  D:\dev\c\rktest\tests\integer_tests.c(105): error: Expected (int_sum1) <= (int_sum2), actual: 53 vs 17
+   
+  [  FAILED  ] integer_tests.expect_less_than_equal 
+  [ RUN      ] integer_tests.expect_less_than_equal_info 
+  D:\dev\c\rktest\tests\integer_tests.c(115): error: Expected (int_sum1) <= (int_sum2), actual: 53 vs 17
+  int_sum2 = 17
+  
+  [  FAILED  ] integer_tests.expect_less_than_equal_info 
   [ RUN      ] integer_tests.expect_greater_than 
-  [       OK ] integer_tests.expect_greater_than 
+  D:\dev\c\rktest\tests\integer_tests.c(125): error: Expected (int_sum2) > (int_sum1), actual: 17 vs 53
+   
+  [  FAILED  ] integer_tests.expect_greater_than 
+  [ RUN      ] integer_tests.expect_greater_than_info 
+  D:\dev\c\rktest\tests\integer_tests.c(135): error: Expected (int_sum2) > (int_sum1), actual: 17 vs 53
+  int_sum2 = 17
+  
+  [  FAILED  ] integer_tests.expect_greater_than_info 
   [ RUN      ] integer_tests.expect_greater_than_equal 
-  [       OK ] integer_tests.expect_greater_than_equal 
-  [----------] 8 tests from integer_tests 
+  D:\dev\c\rktest\tests\integer_tests.c(145): error: Expected (int_sum2) >= (int_sum1), actual: 17 vs 53
+   
+  [  FAILED  ] integer_tests.expect_greater_than_equal 
+  [ RUN      ] integer_tests.expect_greater_than_equal_info 
+  D:\dev\c\rktest\tests\integer_tests.c(155): error: Expected (int_sum2) >= (int_sum1), actual: 17 vs 53
+  int_sum2 = 17
+  
+  [  FAILED  ] integer_tests.expect_greater_than_equal_info 
+  [----------] 16 tests from integer_tests 
   
   [----------] 4 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
@@ -65,8 +124,112 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 22 tests from 5 test suites ran. 
-  [  PASSED  ] 22 tests.
+  [==========] 30 tests from 5 test suites ran. 
+  [  PASSED  ] 17 tests.
+  [  FAILED  ] 13 tests, listed below:
+  [  FAILED  ] integer_tests.expect_true
+  [  FAILED  ] integer_tests.expect_true_info
+  [  FAILED  ] integer_tests.expect_false
+  [  FAILED  ] integer_tests.expect_equal
+  [  FAILED  ] integer_tests.expect_equal_info
+  [  FAILED  ] integer_tests.expect_less_than
+  [  FAILED  ] integer_tests.expect_less_than_info
+  [  FAILED  ] integer_tests.expect_less_than_equal
+  [  FAILED  ] integer_tests.expect_less_than_equal_info
+  [  FAILED  ] integer_tests.expect_greater_than
+  [  FAILED  ] integer_tests.expect_greater_than_info
+  [  FAILED  ] integer_tests.expect_greater_than_equal
+  [  FAILED  ] integer_tests.expect_greater_than_equal_info
+  
+   13 FAILED TESTs
+    YOU HAVE 1 DISABLED TEST
+  
+  '''
+# ---
+# name: test_infix_match
+  '''
+  Note: Test filter = *tests*
+  [==========] Running 30 tests from 5 test suites.
+  [----------] Global test environment set-up.
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
+  [----------] 2 tests from float_tests
+  [ RUN      ] float_tests.float_equal 
+  [       OK ] float_tests.float_equal 
+  [ RUN      ] float_tests.double_equal 
+  [       OK ] float_tests.double_equal 
+  [----------] 2 tests from float_tests 
+  
+  [----------] 16 tests from integer_tests
+  [ RUN      ] integer_tests.expect_true 
+  [       OK ] integer_tests.expect_true 
+  [ RUN      ] integer_tests.expect_true_info 
+  [       OK ] integer_tests.expect_true_info 
+  [ RUN      ] integer_tests.expect_false 
+  [       OK ] integer_tests.expect_false 
+  [ RUN      ] integer_tests.expect_false_info 
+  [       OK ] integer_tests.expect_false_info 
+  [ RUN      ] integer_tests.expect_equal 
+  [       OK ] integer_tests.expect_equal 
+  [ RUN      ] integer_tests.expect_equal_info 
+  [       OK ] integer_tests.expect_equal_info 
+  [ RUN      ] integer_tests.expect_not_equal 
+  [       OK ] integer_tests.expect_not_equal 
+  [ RUN      ] integer_tests.expect_not_equal_info 
+  [       OK ] integer_tests.expect_not_equal_info 
+  [ RUN      ] integer_tests.expect_less_than 
+  [       OK ] integer_tests.expect_less_than 
+  [ RUN      ] integer_tests.expect_less_than_info 
+  [       OK ] integer_tests.expect_less_than_info 
+  [ RUN      ] integer_tests.expect_less_than_equal 
+  [       OK ] integer_tests.expect_less_than_equal 
+  [ RUN      ] integer_tests.expect_less_than_equal_info 
+  [       OK ] integer_tests.expect_less_than_equal_info 
+  [ RUN      ] integer_tests.expect_greater_than 
+  [       OK ] integer_tests.expect_greater_than 
+  [ RUN      ] integer_tests.expect_greater_than_info 
+  [       OK ] integer_tests.expect_greater_than_info 
+  [ RUN      ] integer_tests.expect_greater_than_equal 
+  [       OK ] integer_tests.expect_greater_than_equal 
+  [ RUN      ] integer_tests.expect_greater_than_equal_info 
+  [       OK ] integer_tests.expect_greater_than_equal_info 
+  [----------] 16 tests from integer_tests 
+  
+  [----------] 4 tests from string_tests
+  [ RUN      ] string_tests.strings_equal 
+  [       OK ] string_tests.strings_equal 
+  [ RUN      ] string_tests.strings_not_equal 
+  [       OK ] string_tests.strings_not_equal 
+  [ RUN      ] string_tests.strings_case_equal 
+  [       OK ] string_tests.strings_case_equal 
+  [ RUN      ] string_tests.strings_case_not_equal 
+  [       OK ] string_tests.strings_case_not_equal 
+  [----------] 4 tests from string_tests 
+  
+  [----------] 7 tests from wildcard_match_tests
+  [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
+  [       OK ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
+  [ RUN      ] wildcard_match_tests.literal_pattern_matches_only_exact_literal 
+  [       OK ] wildcard_match_tests.literal_pattern_matches_only_exact_literal 
+  [ RUN      ] wildcard_match_tests.single_asterisk_matches_any_string 
+  [       OK ] wildcard_match_tests.single_asterisk_matches_any_string 
+  [ RUN      ] wildcard_match_tests.literal_then_asterisk_does_prefix_match 
+  [       OK ] wildcard_match_tests.literal_then_asterisk_does_prefix_match 
+  [ RUN      ] wildcard_match_tests.asterisk_then_literal_does_suffix_match 
+  [       OK ] wildcard_match_tests.asterisk_then_literal_does_suffix_match 
+  [ RUN      ] wildcard_match_tests.prefix_and_suffix_match 
+  [       OK ] wildcard_match_tests.prefix_and_suffix_match 
+  [ RUN      ] wildcard_match_tests.infix_match 
+  [       OK ] wildcard_match_tests.infix_match 
+  [----------] 7 tests from wildcard_match_tests 
+  
+  [----------] Global test environment tear-down.
+  [==========] 30 tests from 5 test suites ran. 
+  [  PASSED  ] 30 tests.
   
     YOU HAVE 1 DISABLED TEST
   
@@ -74,7 +237,7 @@
 # ---
 # name: test_no_args
   '''
-  [==========] Running 22 tests from 5 test suites.
+  [==========] Running 30 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -89,24 +252,40 @@
   [       OK ] float_tests.double_equal 
   [----------] 2 tests from float_tests 
   
-  [----------] 8 tests from integer_tests
+  [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
   [       OK ] integer_tests.expect_true 
+  [ RUN      ] integer_tests.expect_true_info 
+  [       OK ] integer_tests.expect_true_info 
   [ RUN      ] integer_tests.expect_false 
   [       OK ] integer_tests.expect_false 
+  [ RUN      ] integer_tests.expect_false_info 
+  [       OK ] integer_tests.expect_false_info 
   [ RUN      ] integer_tests.expect_equal 
   [       OK ] integer_tests.expect_equal 
+  [ RUN      ] integer_tests.expect_equal_info 
+  [       OK ] integer_tests.expect_equal_info 
   [ RUN      ] integer_tests.expect_not_equal 
   [       OK ] integer_tests.expect_not_equal 
+  [ RUN      ] integer_tests.expect_not_equal_info 
+  [       OK ] integer_tests.expect_not_equal_info 
   [ RUN      ] integer_tests.expect_less_than 
   [       OK ] integer_tests.expect_less_than 
+  [ RUN      ] integer_tests.expect_less_than_info 
+  [       OK ] integer_tests.expect_less_than_info 
   [ RUN      ] integer_tests.expect_less_than_equal 
   [       OK ] integer_tests.expect_less_than_equal 
+  [ RUN      ] integer_tests.expect_less_than_equal_info 
+  [       OK ] integer_tests.expect_less_than_equal_info 
   [ RUN      ] integer_tests.expect_greater_than 
   [       OK ] integer_tests.expect_greater_than 
+  [ RUN      ] integer_tests.expect_greater_than_info 
+  [       OK ] integer_tests.expect_greater_than_info 
   [ RUN      ] integer_tests.expect_greater_than_equal 
   [       OK ] integer_tests.expect_greater_than_equal 
-  [----------] 8 tests from integer_tests 
+  [ RUN      ] integer_tests.expect_greater_than_equal_info 
+  [       OK ] integer_tests.expect_greater_than_equal_info 
+  [----------] 16 tests from integer_tests 
   
   [----------] 4 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
@@ -137,8 +316,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 22 tests from 5 test suites ran. 
-  [  PASSED  ] 22 tests.
+  [==========] 30 tests from 5 test suites ran. 
+  [  PASSED  ] 30 tests.
   
     YOU HAVE 1 DISABLED TEST
   
@@ -147,30 +326,46 @@
 # name: test_prefix_match
   '''
   Note: Test filter = integer*
-  [==========] Running 8 tests from 1 test suites.
+  [==========] Running 16 tests from 1 test suites.
   [----------] Global test environment set-up.
-  [----------] 8 tests from integer_tests
+  [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
   [       OK ] integer_tests.expect_true 
+  [ RUN      ] integer_tests.expect_true_info 
+  [       OK ] integer_tests.expect_true_info 
   [ RUN      ] integer_tests.expect_false 
   [       OK ] integer_tests.expect_false 
+  [ RUN      ] integer_tests.expect_false_info 
+  [       OK ] integer_tests.expect_false_info 
   [ RUN      ] integer_tests.expect_equal 
   [       OK ] integer_tests.expect_equal 
+  [ RUN      ] integer_tests.expect_equal_info 
+  [       OK ] integer_tests.expect_equal_info 
   [ RUN      ] integer_tests.expect_not_equal 
   [       OK ] integer_tests.expect_not_equal 
+  [ RUN      ] integer_tests.expect_not_equal_info 
+  [       OK ] integer_tests.expect_not_equal_info 
   [ RUN      ] integer_tests.expect_less_than 
   [       OK ] integer_tests.expect_less_than 
+  [ RUN      ] integer_tests.expect_less_than_info 
+  [       OK ] integer_tests.expect_less_than_info 
   [ RUN      ] integer_tests.expect_less_than_equal 
   [       OK ] integer_tests.expect_less_than_equal 
+  [ RUN      ] integer_tests.expect_less_than_equal_info 
+  [       OK ] integer_tests.expect_less_than_equal_info 
   [ RUN      ] integer_tests.expect_greater_than 
   [       OK ] integer_tests.expect_greater_than 
+  [ RUN      ] integer_tests.expect_greater_than_info 
+  [       OK ] integer_tests.expect_greater_than_info 
   [ RUN      ] integer_tests.expect_greater_than_equal 
   [       OK ] integer_tests.expect_greater_than_equal 
-  [----------] 8 tests from integer_tests 
+  [ RUN      ] integer_tests.expect_greater_than_equal_info 
+  [       OK ] integer_tests.expect_greater_than_equal_info 
+  [----------] 16 tests from integer_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 8 tests from 1 test suites ran. 
-  [  PASSED  ] 8 tests.
+  [==========] 16 tests from 1 test suites ran. 
+  [  PASSED  ] 16 tests.
   
   '''
 # ---
@@ -217,7 +412,7 @@
 # name: test_wildcard_match
   '''
   Note: Test filter = *
-  [==========] Running 22 tests from 5 test suites.
+  [==========] Running 30 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -232,24 +427,40 @@
   [       OK ] float_tests.double_equal 
   [----------] 2 tests from float_tests 
   
-  [----------] 8 tests from integer_tests
+  [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
   [       OK ] integer_tests.expect_true 
+  [ RUN      ] integer_tests.expect_true_info 
+  [       OK ] integer_tests.expect_true_info 
   [ RUN      ] integer_tests.expect_false 
   [       OK ] integer_tests.expect_false 
+  [ RUN      ] integer_tests.expect_false_info 
+  [       OK ] integer_tests.expect_false_info 
   [ RUN      ] integer_tests.expect_equal 
   [       OK ] integer_tests.expect_equal 
+  [ RUN      ] integer_tests.expect_equal_info 
+  [       OK ] integer_tests.expect_equal_info 
   [ RUN      ] integer_tests.expect_not_equal 
   [       OK ] integer_tests.expect_not_equal 
+  [ RUN      ] integer_tests.expect_not_equal_info 
+  [       OK ] integer_tests.expect_not_equal_info 
   [ RUN      ] integer_tests.expect_less_than 
   [       OK ] integer_tests.expect_less_than 
+  [ RUN      ] integer_tests.expect_less_than_info 
+  [       OK ] integer_tests.expect_less_than_info 
   [ RUN      ] integer_tests.expect_less_than_equal 
   [       OK ] integer_tests.expect_less_than_equal 
+  [ RUN      ] integer_tests.expect_less_than_equal_info 
+  [       OK ] integer_tests.expect_less_than_equal_info 
   [ RUN      ] integer_tests.expect_greater_than 
   [       OK ] integer_tests.expect_greater_than 
+  [ RUN      ] integer_tests.expect_greater_than_info 
+  [       OK ] integer_tests.expect_greater_than_info 
   [ RUN      ] integer_tests.expect_greater_than_equal 
   [       OK ] integer_tests.expect_greater_than_equal 
-  [----------] 8 tests from integer_tests 
+  [ RUN      ] integer_tests.expect_greater_than_equal_info 
+  [       OK ] integer_tests.expect_greater_than_equal_info 
+  [----------] 16 tests from integer_tests 
   
   [----------] 4 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
@@ -280,8 +491,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 22 tests from 5 test suites ran. 
-  [  PASSED  ] 22 tests.
+  [==========] 30 tests from 5 test suites ran. 
+  [  PASSED  ] 30 tests.
   
     YOU HAVE 1 DISABLED TEST
   

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -3,12 +3,6 @@
   '''
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
-  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   D:\dev\c\rktest\tests\float_tests.c(12): error: Expected equality of these values:
@@ -185,6 +179,12 @@
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
   
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 15 tests.
@@ -211,8 +211,8 @@
   [  FAILED  ] string_tests.strings_case_equal
   [  FAILED  ] string_tests.strings_case_equal_info
   
-   21 FAILED TESTs
-    YOU HAVE 1 DISABLED TEST
+   21 FAILED TESTS
+    YOU HAVE 2 DISABLED TESTS
   
   '''
 # ---
@@ -221,12 +221,6 @@
   Note: Test filter = *tests*
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
-  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
@@ -309,11 +303,17 @@
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
   
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 36 tests.
   
-    YOU HAVE 1 DISABLED TEST
+    YOU HAVE 2 DISABLED TESTS
   
   '''
 # ---
@@ -321,12 +321,6 @@
   '''
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
-  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
@@ -409,11 +403,17 @@
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
   
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 36 tests.
   
-    YOU HAVE 1 DISABLED TEST
+    YOU HAVE 2 DISABLED TESTS
   
   '''
 # ---
@@ -508,12 +508,6 @@
   Note: Test filter = *
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
-  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
@@ -596,11 +590,17 @@
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
   
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 36 tests.
   
-    YOU HAVE 1 DISABLED TEST
+    YOU HAVE 2 DISABLED TESTS
   
   '''
 # ---

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_failing_tests
   '''
-  [==========] Running 32 tests from 5 test suites.
+  [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -125,16 +125,48 @@
   [  FAILED  ] integer_tests.expect_greater_than_equal_info 
   [----------] 16 tests from integer_tests 
   
-  [----------] 4 tests from string_tests
+  [----------] 8 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
-  [       OK ] string_tests.strings_equal 
+  D:\dev\c\rktest\tests\string_tests.c(12): error: Expected equality of these values:
+    str1
+      Which is: elloh
+    "hello"
+   
+  [  FAILED  ] string_tests.strings_equal 
+  [ RUN      ] string_tests.strings_equal_info 
+  D:\dev\c\rktest\tests\string_tests.c(17): error: Expected equality of these values:
+    str2
+      Which is: dlorw
+    "world"
+  str2 = dlorw
+  
+  [  FAILED  ] string_tests.strings_equal_info 
   [ RUN      ] string_tests.strings_not_equal 
   [       OK ] string_tests.strings_not_equal 
+  [ RUN      ] string_tests.strings_not_equal_info 
+  [       OK ] string_tests.strings_not_equal_info 
   [ RUN      ] string_tests.strings_case_equal 
-  [       OK ] string_tests.strings_case_equal 
+  D:\dev\c\rktest\tests\string_tests.c(32): error: Expected equality of these values:
+    str1
+      Which is: elloh
+    "Hello"
+  Ignoring case
+   
+  [  FAILED  ] string_tests.strings_case_equal 
+  [ RUN      ] string_tests.strings_case_equal_info 
+  D:\dev\c\rktest\tests\string_tests.c(37): error: Expected equality of these values:
+    str2
+      Which is: dlorw
+    "World"
+  Ignoring case
+  str2 = dlorw
+  
+  [  FAILED  ] string_tests.strings_case_equal_info 
   [ RUN      ] string_tests.strings_case_not_equal 
   [       OK ] string_tests.strings_case_not_equal 
-  [----------] 4 tests from string_tests 
+  [ RUN      ] string_tests.strings_case_not_equal_info 
+  [       OK ] string_tests.strings_case_not_equal_info 
+  [----------] 8 tests from string_tests 
   
   [----------] 7 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
@@ -154,9 +186,9 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 32 tests from 5 test suites ran. 
+  [==========] 36 tests from 5 test suites ran. 
   [  PASSED  ] 15 tests.
-  [  FAILED  ] 17 tests, listed below:
+  [  FAILED  ] 21 tests, listed below:
   [  FAILED  ] float_tests.float_equal
   [  FAILED  ] float_tests.float_equal_info
   [  FAILED  ] float_tests.double_equal
@@ -174,8 +206,12 @@
   [  FAILED  ] integer_tests.expect_greater_than_info
   [  FAILED  ] integer_tests.expect_greater_than_equal
   [  FAILED  ] integer_tests.expect_greater_than_equal_info
+  [  FAILED  ] string_tests.strings_equal
+  [  FAILED  ] string_tests.strings_equal_info
+  [  FAILED  ] string_tests.strings_case_equal
+  [  FAILED  ] string_tests.strings_case_equal_info
   
-   17 FAILED TESTs
+   21 FAILED TESTs
     YOU HAVE 1 DISABLED TEST
   
   '''
@@ -183,7 +219,7 @@
 # name: test_infix_match
   '''
   Note: Test filter = *tests*
-  [==========] Running 32 tests from 5 test suites.
+  [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -237,16 +273,24 @@
   [       OK ] integer_tests.expect_greater_than_equal_info 
   [----------] 16 tests from integer_tests 
   
-  [----------] 4 tests from string_tests
+  [----------] 8 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
   [       OK ] string_tests.strings_equal 
+  [ RUN      ] string_tests.strings_equal_info 
+  [       OK ] string_tests.strings_equal_info 
   [ RUN      ] string_tests.strings_not_equal 
   [       OK ] string_tests.strings_not_equal 
+  [ RUN      ] string_tests.strings_not_equal_info 
+  [       OK ] string_tests.strings_not_equal_info 
   [ RUN      ] string_tests.strings_case_equal 
   [       OK ] string_tests.strings_case_equal 
+  [ RUN      ] string_tests.strings_case_equal_info 
+  [       OK ] string_tests.strings_case_equal_info 
   [ RUN      ] string_tests.strings_case_not_equal 
   [       OK ] string_tests.strings_case_not_equal 
-  [----------] 4 tests from string_tests 
+  [ RUN      ] string_tests.strings_case_not_equal_info 
+  [       OK ] string_tests.strings_case_not_equal_info 
+  [----------] 8 tests from string_tests 
   
   [----------] 7 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
@@ -266,8 +310,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 32 tests from 5 test suites ran. 
-  [  PASSED  ] 32 tests.
+  [==========] 36 tests from 5 test suites ran. 
+  [  PASSED  ] 36 tests.
   
     YOU HAVE 1 DISABLED TEST
   
@@ -275,7 +319,7 @@
 # ---
 # name: test_no_args
   '''
-  [==========] Running 32 tests from 5 test suites.
+  [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -329,16 +373,24 @@
   [       OK ] integer_tests.expect_greater_than_equal_info 
   [----------] 16 tests from integer_tests 
   
-  [----------] 4 tests from string_tests
+  [----------] 8 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
   [       OK ] string_tests.strings_equal 
+  [ RUN      ] string_tests.strings_equal_info 
+  [       OK ] string_tests.strings_equal_info 
   [ RUN      ] string_tests.strings_not_equal 
   [       OK ] string_tests.strings_not_equal 
+  [ RUN      ] string_tests.strings_not_equal_info 
+  [       OK ] string_tests.strings_not_equal_info 
   [ RUN      ] string_tests.strings_case_equal 
   [       OK ] string_tests.strings_case_equal 
+  [ RUN      ] string_tests.strings_case_equal_info 
+  [       OK ] string_tests.strings_case_equal_info 
   [ RUN      ] string_tests.strings_case_not_equal 
   [       OK ] string_tests.strings_case_not_equal 
-  [----------] 4 tests from string_tests 
+  [ RUN      ] string_tests.strings_case_not_equal_info 
+  [       OK ] string_tests.strings_case_not_equal_info 
+  [----------] 8 tests from string_tests 
   
   [----------] 7 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
@@ -358,8 +410,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 32 tests from 5 test suites ran. 
-  [  PASSED  ] 32 tests.
+  [==========] 36 tests from 5 test suites ran. 
+  [  PASSED  ] 36 tests.
   
     YOU HAVE 1 DISABLED TEST
   
@@ -454,7 +506,7 @@
 # name: test_wildcard_match
   '''
   Note: Test filter = *
-  [==========] Running 32 tests from 5 test suites.
+  [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -508,16 +560,24 @@
   [       OK ] integer_tests.expect_greater_than_equal_info 
   [----------] 16 tests from integer_tests 
   
-  [----------] 4 tests from string_tests
+  [----------] 8 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
   [       OK ] string_tests.strings_equal 
+  [ RUN      ] string_tests.strings_equal_info 
+  [       OK ] string_tests.strings_equal_info 
   [ RUN      ] string_tests.strings_not_equal 
   [       OK ] string_tests.strings_not_equal 
+  [ RUN      ] string_tests.strings_not_equal_info 
+  [       OK ] string_tests.strings_not_equal_info 
   [ RUN      ] string_tests.strings_case_equal 
   [       OK ] string_tests.strings_case_equal 
+  [ RUN      ] string_tests.strings_case_equal_info 
+  [       OK ] string_tests.strings_case_equal_info 
   [ RUN      ] string_tests.strings_case_not_equal 
   [       OK ] string_tests.strings_case_not_equal 
-  [----------] 4 tests from string_tests 
+  [ RUN      ] string_tests.strings_case_not_equal_info 
+  [       OK ] string_tests.strings_case_not_equal_info 
+  [----------] 8 tests from string_tests 
   
   [----------] 7 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
@@ -537,8 +597,8 @@
   [----------] 7 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 32 tests from 5 test suites ran. 
-  [  PASSED  ] 32 tests.
+  [==========] 36 tests from 5 test suites ran. 
+  [  PASSED  ] 36 tests.
   
     YOU HAVE 1 DISABLED TEST
   

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -3,9 +3,15 @@
   '''
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
-  D:\dev\c\rktest\tests\float_tests.c(12): error: Expected equality of these values:
+  error: Expected equality of these values:
     float_sum
       Which is: 1.00000000
     0.9f
@@ -13,7 +19,7 @@
    
   [  FAILED  ] float_tests.float_equal 
   [ RUN      ] float_tests.float_equal_info 
-  D:\dev\c\rktest\tests\float_tests.c(17): error: Expected equality of these values:
+  error: Expected equality of these values:
     float_sum
       Which is: 1.00000000
     0.9f
@@ -22,7 +28,7 @@
   
   [  FAILED  ] float_tests.float_equal_info 
   [ RUN      ] float_tests.double_equal 
-  D:\dev\c\rktest\tests\float_tests.c(22): error: Expected equality of these values:
+  error: Expected equality of these values:
     double_sum
       Which is: 1.00000000
     0.9
@@ -30,7 +36,7 @@
    
   [  FAILED  ] float_tests.double_equal 
   [ RUN      ] float_tests.double_equal_info 
-  D:\dev\c\rktest\tests\float_tests.c(27): error: Expected equality of these values:
+  error: Expected equality of these values:
     double_sum
       Which is: 1.00000000
     0.9
@@ -42,20 +48,20 @@
   
   [----------] 16 tests from integer_tests
   [ RUN      ] integer_tests.expect_true 
-  D:\dev\c\rktest\tests\integer_tests.c(23): error: Value of: `int_sum1 == 3`:
+  error: Value of: `int_sum1 == 3`:
     Actual: false
   Expected: true
    
   [  FAILED  ] integer_tests.expect_true 
   [ RUN      ] integer_tests.expect_true_info 
-  D:\dev\c\rktest\tests\integer_tests.c(28): error: Value of: `int_sum2 == 7`:
+  error: Value of: `int_sum2 == 7`:
     Actual: false
   Expected: true
   int_sum2 = 17
   
   [  FAILED  ] integer_tests.expect_true_info 
   [ RUN      ] integer_tests.expect_false 
-  D:\dev\c\rktest\tests\integer_tests.c(33): error: Value of: `int_sum1 == 1 + 2 + 50`:
+  error: Value of: `int_sum1 == 1 + 2 + 50`:
     Actual: true
   Expected: false
    
@@ -63,14 +69,14 @@
   [ RUN      ] integer_tests.expect_false_info 
   [       OK ] integer_tests.expect_false_info 
   [ RUN      ] integer_tests.expect_equal 
-  D:\dev\c\rktest\tests\integer_tests.c(44): error: Expected equality of these values:
+  error: Expected equality of these values:
     int_sum1
       Which is: 53
     3
    
   [  FAILED  ] integer_tests.expect_equal 
   [ RUN      ] integer_tests.expect_equal_info 
-  D:\dev\c\rktest\tests\integer_tests.c(54): error: Expected equality of these values:
+  error: Expected equality of these values:
     int_sum2
       Which is: 17
     7
@@ -82,38 +88,38 @@
   [ RUN      ] integer_tests.expect_not_equal_info 
   [       OK ] integer_tests.expect_not_equal_info 
   [ RUN      ] integer_tests.expect_less_than 
-  D:\dev\c\rktest\tests\integer_tests.c(85): error: Expected (int_sum1) < (int_sum2), actual: 53 vs 17
+  error: Expected (int_sum1) < (int_sum2), actual: 53 vs 17
    
   [  FAILED  ] integer_tests.expect_less_than 
   [ RUN      ] integer_tests.expect_less_than_info 
-  D:\dev\c\rktest\tests\integer_tests.c(95): error: Expected (int_sum1) < (int_sum2), actual: 53 vs 17
+  error: Expected (int_sum1) < (int_sum2), actual: 53 vs 17
   int_sum2 = 17
   
   [  FAILED  ] integer_tests.expect_less_than_info 
   [ RUN      ] integer_tests.expect_less_than_equal 
-  D:\dev\c\rktest\tests\integer_tests.c(105): error: Expected (int_sum1) <= (int_sum2), actual: 53 vs 17
+  error: Expected (int_sum1) <= (int_sum2), actual: 53 vs 17
    
   [  FAILED  ] integer_tests.expect_less_than_equal 
   [ RUN      ] integer_tests.expect_less_than_equal_info 
-  D:\dev\c\rktest\tests\integer_tests.c(115): error: Expected (int_sum1) <= (int_sum2), actual: 53 vs 17
+  error: Expected (int_sum1) <= (int_sum2), actual: 53 vs 17
   int_sum2 = 17
   
   [  FAILED  ] integer_tests.expect_less_than_equal_info 
   [ RUN      ] integer_tests.expect_greater_than 
-  D:\dev\c\rktest\tests\integer_tests.c(125): error: Expected (int_sum2) > (int_sum1), actual: 17 vs 53
+  error: Expected (int_sum2) > (int_sum1), actual: 17 vs 53
    
   [  FAILED  ] integer_tests.expect_greater_than 
   [ RUN      ] integer_tests.expect_greater_than_info 
-  D:\dev\c\rktest\tests\integer_tests.c(135): error: Expected (int_sum2) > (int_sum1), actual: 17 vs 53
+  error: Expected (int_sum2) > (int_sum1), actual: 17 vs 53
   int_sum2 = 17
   
   [  FAILED  ] integer_tests.expect_greater_than_info 
   [ RUN      ] integer_tests.expect_greater_than_equal 
-  D:\dev\c\rktest\tests\integer_tests.c(145): error: Expected (int_sum2) >= (int_sum1), actual: 17 vs 53
+  error: Expected (int_sum2) >= (int_sum1), actual: 17 vs 53
    
   [  FAILED  ] integer_tests.expect_greater_than_equal 
   [ RUN      ] integer_tests.expect_greater_than_equal_info 
-  D:\dev\c\rktest\tests\integer_tests.c(155): error: Expected (int_sum2) >= (int_sum1), actual: 17 vs 53
+  error: Expected (int_sum2) >= (int_sum1), actual: 17 vs 53
   int_sum2 = 17
   
   [  FAILED  ] integer_tests.expect_greater_than_equal_info 
@@ -121,14 +127,14 @@
   
   [----------] 8 tests from string_tests
   [ RUN      ] string_tests.strings_equal 
-  D:\dev\c\rktest\tests\string_tests.c(12): error: Expected equality of these values:
+  error: Expected equality of these values:
     str1
       Which is: elloh
     "hello"
    
   [  FAILED  ] string_tests.strings_equal 
   [ RUN      ] string_tests.strings_equal_info 
-  D:\dev\c\rktest\tests\string_tests.c(17): error: Expected equality of these values:
+  error: Expected equality of these values:
     str2
       Which is: dlorw
     "world"
@@ -140,7 +146,7 @@
   [ RUN      ] string_tests.strings_not_equal_info 
   [       OK ] string_tests.strings_not_equal_info 
   [ RUN      ] string_tests.strings_case_equal 
-  D:\dev\c\rktest\tests\string_tests.c(32): error: Expected equality of these values:
+  error: Expected equality of these values:
     str1
       Which is: elloh
     "Hello"
@@ -148,7 +154,7 @@
    
   [  FAILED  ] string_tests.strings_case_equal 
   [ RUN      ] string_tests.strings_case_equal_info 
-  D:\dev\c\rktest\tests\string_tests.c(37): error: Expected equality of these values:
+  error: Expected equality of these values:
     str2
       Which is: dlorw
     "World"
@@ -178,12 +184,6 @@
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
-  
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
   
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
@@ -221,6 +221,12 @@
   Note: Test filter = *tests*
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
@@ -302,12 +308,6 @@
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
-  
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
   
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
@@ -321,6 +321,12 @@
   '''
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
@@ -402,12 +408,6 @@
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
-  
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
   
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 
@@ -508,6 +508,12 @@
   Note: Test filter = *
   [==========] Running 36 tests from 5 test suites.
   [----------] Global test environment set-up.
+  [----------] 1 tests from disabled_tests
+  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
+  [ RUN      ] disabled_tests.this_test_should_run 
+  [       OK ] disabled_tests.this_test_should_run 
+  [----------] 1 tests from disabled_tests 
+  
   [----------] 4 tests from float_tests
   [ RUN      ] float_tests.float_equal 
   [       OK ] float_tests.float_equal 
@@ -589,12 +595,6 @@
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
   [----------] 7 tests from wildcard_match_tests 
-  
-  [----------] 1 tests from disabled_tests
-  [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
-  [ RUN      ] disabled_tests.this_test_should_run 
-  [       OK ] disabled_tests.this_test_should_run 
-  [----------] 1 tests from disabled_tests 
   
   [----------] Global test environment tear-down.
   [==========] 36 tests from 5 test suites ran. 

--- a/tests/disabled_tests.c
+++ b/tests/disabled_tests.c
@@ -1,9 +1,15 @@
 #include <rktest/rktest.h>
 
+// This test suite should show up, but this test should be printed as [ DISABLED ]
 TEST(disabled_tests, DISABLED_this_test_should_not_run) {
 	EXPECT_EQ(1 + 1, 3);
 }
 
 TEST(disabled_tests, this_test_should_run) {
 	EXPECT_EQ(1 + 1, 2);
+}
+
+// This suite test should NOT show up since all its tests are disabled
+TEST(disabled_tests2, DISABLED_this_test_should_not_run) {
+	EXPECT_EQ(1 + 1, 3);
 }

--- a/tests/disabled_tests.c
+++ b/tests/disabled_tests.c
@@ -13,3 +13,7 @@ TEST(disabled_tests, this_test_should_run) {
 TEST(disabled_tests2, DISABLED_this_test_should_not_run) {
 	EXPECT_EQ(1 + 1, 3);
 }
+
+TEST(disabled_tests2, DISABLED_this_test_should_not_run_either) {
+	EXPECT_EQ(1 + 1, 5);
+}

--- a/tests/float_tests.c
+++ b/tests/float_tests.c
@@ -1,20 +1,29 @@
 #include <rktest/rktest.h>
 
+#ifndef RKTEST_FAILING_TESTS
 const float float_sum = 0.3f + 0.3f + 0.3f;
 const double double_sum = 0.3 + 0.3 + 0.3;
+#else
+const float float_sum = 0.3f + 0.3f + 0.3f + 0.1f;
+const double double_sum = 0.3 + 0.3 + 0.3 + 0.1;
+#endif
 
 TEST(float_tests, float_equal) {
 	ASSERT_FLOAT_EQ(float_sum, 0.9f);
-	ASSERT_FLOAT_EQ_INFO(float_sum, 0.9f, "float_sum = %f\n", float_sum);
-
 	EXPECT_FLOAT_EQ(float_sum, 0.9f);
-	EXPECT_FLOAT_EQ_INFO(float_sum, 0.9f, "float_sum = %f\n", float_sum);
+}
+
+TEST(float_tests, float_equal_info) {
+	ASSERT_FLOAT_EQ_INFO(float_sum, 0.9f, "Hello world!\n");
+	EXPECT_FLOAT_EQ_INFO(float_sum, 0.9f, "Hello world!\n");
 }
 
 TEST(float_tests, double_equal) {
 	ASSERT_DOUBLE_EQ(double_sum, 0.9);
-	ASSERT_DOUBLE_EQ_INFO(double_sum, 0.9, "double_sum = %f\n", double_sum);
-
 	EXPECT_DOUBLE_EQ(double_sum, 0.9);
-	EXPECT_DOUBLE_EQ_INFO(double_sum, 0.9, "double_sum = %f\n", double_sum);
+}
+
+TEST(float_tests, double_equal_info) {
+	ASSERT_DOUBLE_EQ_INFO(double_sum, 0.9, "Hello world!\n");
+	EXPECT_DOUBLE_EQ_INFO(double_sum, 0.9, "Hello world!\n");
 }

--- a/tests/integer_tests.c
+++ b/tests/integer_tests.c
@@ -2,28 +2,40 @@
 
 #include <stdint.h>
 
-// defining variables here to easily control if tests pass or fail.
+#ifndef RKTEST_FAILING_TESTS
 static const int int_sum1 = 1 + 2;
 static const int int_sum2 = 3 + 4;
 static const char char_sum1 = 1 + 2;
 static const char char_sum2 = 3 + 4;
 static const long long_sum1 = 1 + 2;
 static const long long_sum2 = 3 + 4;
+#else
+static const int int_sum1 = 1 + 2 + 50;
+static const int int_sum2 = 3 + 4 + 10;
+static const char char_sum1 = 1 + 2 + 10;
+static const char char_sum2 = 3 + 4 + 10;
+static const long long_sum1 = 1 + 2 + 10;
+static const long long_sum2 = 3 + 4 + 10;
+#endif
 
 /* Predicate checks */
 TEST(integer_tests, expect_true) {
 	ASSERT_TRUE(int_sum1 == 3);
-	ASSERT_TRUE_INFO(int_sum2 == 7, "int_sum2 = %d\n", int_sum2);
-
 	EXPECT_TRUE(int_sum1 == 3);
+}
+
+TEST(integer_tests, expect_true_info) {
+	ASSERT_TRUE_INFO(int_sum2 == 7, "int_sum2 = %d\n", int_sum2);
 	EXPECT_TRUE_INFO(int_sum2 == 7, "int_sum2 = %d\n", int_sum2);
 }
 
 TEST(integer_tests, expect_false) {
-	ASSERT_FALSE(int_sum1 == int_sum2);
-	ASSERT_FALSE_INFO(int_sum1 == int_sum2, "int_sum2 = %d", int_sum2);
-
+	ASSERT_FALSE(int_sum1 == 1 + 2 + 50);
 	EXPECT_FALSE(int_sum1 == int_sum2);
+}
+
+TEST(integer_tests, expect_false_info) {
+	ASSERT_FALSE_INFO(int_sum1 == int_sum2, "int_sum2 = %d", int_sum2);
 	EXPECT_FALSE_INFO(int_sum1 == int_sum2, "int_sum2 = %d", int_sum2);
 }
 
@@ -36,7 +48,9 @@ TEST(integer_tests, expect_equal) {
 	EXPECT_EQ(int_sum1, 3);
 	EXPECT_EQ(char_sum1, 3);
 	EXPECT_LONG_EQ(long_sum1, 3);
+}
 
+TEST(integer_tests, expect_equal_info) {
 	ASSERT_EQ_INFO(int_sum2, 7, "int_sum2 = %d\n", int_sum2);
 	ASSERT_EQ_INFO(char_sum2, 7, "char_sum2 = %d\n", char_sum2);
 	ASSERT_LONG_EQ_INFO(long_sum2, 7, "long_sum2 = %ld\n", long_sum2);
@@ -54,14 +68,16 @@ TEST(integer_tests, expect_not_equal) {
 	EXPECT_NE(int_sum1, int_sum2);
 	EXPECT_NE(char_sum1, char_sum2);
 	EXPECT_LONG_NE(long_sum1, long_sum2);
+}
 
-	ASSERT_NE_INFO(int_sum1, int_sum2, "int_sum2 = %d\n", int_sum2);
-	ASSERT_NE_INFO(char_sum1, char_sum2, "char_sum2 = %d\n", char_sum2);
-	ASSERT_LONG_NE_INFO(long_sum1, long_sum2, "long_sum2 = %ld\n", long_sum2);
+TEST(integer_tests, expect_not_equal_info) {
+	ASSERT_NE(int_sum1, int_sum2);
+	ASSERT_NE(char_sum1, char_sum2);
+	ASSERT_LONG_NE(long_sum1, long_sum2);
 
-	EXPECT_NE_INFO(int_sum1, int_sum2, "int_sum2 = %d\n", int_sum2);
-	EXPECT_NE_INFO(char_sum1, char_sum2, "char_sum2 = %d\n", char_sum2);
-	EXPECT_LONG_NE_INFO(long_sum1, long_sum2, "long_sum2 = %ld\n", long_sum2);
+	EXPECT_NE(int_sum1, int_sum2);
+	EXPECT_NE(char_sum1, char_sum2);
+	EXPECT_LONG_NE(long_sum1, long_sum2);
 }
 
 /* Comparison checks */
@@ -73,7 +89,9 @@ TEST(integer_tests, expect_less_than) {
 	EXPECT_LT(int_sum1, int_sum2);
 	EXPECT_LT(char_sum1, char_sum2);
 	EXPECT_LONG_LT(long_sum1, long_sum2);
+}
 
+TEST(integer_tests, expect_less_than_info) {
 	ASSERT_LT_INFO(int_sum1, int_sum2, "int_sum2 = %d\n", int_sum2);
 	ASSERT_LT_INFO(char_sum1, char_sum2, "char_sum2 = %d\n", char_sum2);
 	ASSERT_LONG_LT_INFO(long_sum1, long_sum2, "long_sum2 = %ld\n", long_sum2);
@@ -91,7 +109,9 @@ TEST(integer_tests, expect_less_than_equal) {
 	EXPECT_LE(int_sum1, int_sum2);
 	EXPECT_LE(char_sum1, char_sum2);
 	EXPECT_LONG_LE(long_sum1, long_sum2);
+}
 
+TEST(integer_tests, expect_less_than_equal_info) {
 	ASSERT_LE_INFO(int_sum1, int_sum2, "int_sum2 = %d\n", int_sum2);
 	ASSERT_LE_INFO(char_sum1, char_sum2, "char_sum2 = %d\n", char_sum2);
 	ASSERT_LONG_LE_INFO(long_sum1, long_sum2, "long_sum2 = %ld\n", long_sum2);
@@ -109,7 +129,9 @@ TEST(integer_tests, expect_greater_than) {
 	EXPECT_GT(int_sum2, int_sum1);
 	EXPECT_GT(char_sum2, char_sum1);
 	EXPECT_LONG_GT(long_sum2, long_sum1);
+}
 
+TEST(integer_tests, expect_greater_than_info) {
 	ASSERT_GT_INFO(int_sum2, int_sum1, "int_sum2 = %d\n", int_sum2);
 	ASSERT_GT_INFO(char_sum2, char_sum1, "char_sum2 = %d\n", char_sum2);
 	ASSERT_LONG_GT_INFO(long_sum2, long_sum1, "long_sum2 = %ld\n", long_sum2);
@@ -127,7 +149,9 @@ TEST(integer_tests, expect_greater_than_equal) {
 	EXPECT_GE(int_sum2, int_sum1);
 	EXPECT_GE(char_sum2, char_sum1);
 	EXPECT_LONG_GE(long_sum2, long_sum1);
+}
 
+TEST(integer_tests, expect_greater_than_equal_info) {
 	ASSERT_GE_INFO(int_sum2, int_sum1, "int_sum2 = %d\n", int_sum2);
 	ASSERT_GE_INFO(char_sum2, char_sum1, "char_sum2 = %d\n", char_sum2);
 	ASSERT_LONG_GE_INFO(long_sum2, long_sum1, "long_sum2 = %ld\n", long_sum2);

--- a/tests/snapshot_test.py
+++ b/tests/snapshot_test.py
@@ -2,33 +2,38 @@ import os
 import subprocess
 
 TEST_EXECUTABLE = './build/Debug/tests' if os.name == 'nt' else './build/tests'
+FAILING_TEST_EXECUTABLE = './build/Debug/failing_tests' if os.name == 'nt' else './build/failing_tests'
 
 
-def run_test_exe(args: [str] = []) -> str:
-    result = subprocess.run([TEST_EXECUTABLE, '--rktest_print_time=0',
+def run_test_exe(exe, args: [str] = []) -> str:
+    result = subprocess.run([exe, '--rktest_print_time=0',
                             '--rktest_color=no'] + args, stdout=subprocess.PIPE)
     return result.stdout.decode('utf-8')
 
 
 def test_no_args(snapshot):
-    actual = run_test_exe()
+    actual = run_test_exe(TEST_EXECUTABLE)
     assert actual == snapshot
 
 
 def test_wildcard_match(snapshot):
-    actual = run_test_exe(['--rktest_filter=*'])
+    actual = run_test_exe(TEST_EXECUTABLE, ['--rktest_filter=*'])
     assert actual == snapshot
 
 
 def test_suffix_match(snapshot):
-    actual = run_test_exe(['--rktest_filter=*equal'])
+    actual = run_test_exe(TEST_EXECUTABLE, ['--rktest_filter=*equal'])
     assert actual == snapshot
 
 
 def test_prefix_match(snapshot):
-    actual = run_test_exe(['--rktest_filter=integer*'])
+    actual = run_test_exe(TEST_EXECUTABLE, ['--rktest_filter=integer*'])
     assert actual == snapshot
 
 def test_infix_match(snapshot):
-    actual = run_test_exe(['--rktest_filter=*tests*'])
+    actual = run_test_exe(TEST_EXECUTABLE, ['--rktest_filter=*tests*'])
+    assert actual == snapshot
+
+def test_failing_tests(snapshot):
+    actual = run_test_exe(FAILING_TEST_EXECUTABLE)
     assert actual == snapshot

--- a/tests/snapshot_test.py
+++ b/tests/snapshot_test.py
@@ -6,7 +6,7 @@ FAILING_TEST_EXECUTABLE = './build/Debug/failing_tests' if os.name == 'nt' else 
 
 
 def run_test_exe(exe, args: [str] = []) -> str:
-    result = subprocess.run([exe, '--rktest_print_time=0',
+    result = subprocess.run([exe, '--rktest_print_time=0', '--rktest_print_filenames=0',
                             '--rktest_color=no'] + args, stdout=subprocess.PIPE)
     return result.stdout.decode('utf-8')
 

--- a/tests/string_tests.c
+++ b/tests/string_tests.c
@@ -1,36 +1,49 @@
 #include <rktest/rktest.h>
 
+#ifndef RKTEST_FAILING_TESTS
 const char* str1 = "hello";
 const char* str2 = "world";
+#else
+const char* str1 = "elloh";
+const char* str2 = "dlorw";
+#endif
 
 TEST(string_tests, strings_equal) {
 	ASSERT_STREQ(str1, "hello");
-	ASSERT_STREQ_INFO(str2, "world", "str2 = %s\n", str2);
-
 	EXPECT_STREQ(str1, "hello");
+}
+
+TEST(string_tests, strings_equal_info) {
+	ASSERT_STREQ_INFO(str2, "world", "str2 = %s\n", str2);
 	EXPECT_STREQ_INFO(str2, "world", "str2 = %s\n", str2);
 }
 
 TEST(string_tests, strings_not_equal) {
 	ASSERT_STRNE(str1, "hello123");
-	ASSERT_STRNE_INFO(str2, "world123", "str2 = %s\n", str2);
-
 	EXPECT_STRNE(str1, "hello123");
+}
+
+TEST(string_tests, strings_not_equal_info) {
+	ASSERT_STRNE_INFO(str2, "world123", "str2 = %s\n", str2);
 	EXPECT_STRNE_INFO(str2, "world123", "str2 = %s\n", str2);
 }
 
 TEST(string_tests, strings_case_equal) {
 	ASSERT_CASE_STREQ(str1, "Hello");
-	ASSERT_CASE_STREQ_INFO(str2, "World", "str2 = %s\n", str2);
-
 	EXPECT_CASE_STREQ(str1, "hello");
+}
+
+TEST(string_tests, strings_case_equal_info) {
+	ASSERT_CASE_STREQ_INFO(str2, "World", "str2 = %s\n", str2);
 	EXPECT_CASE_STREQ_INFO(str2, "world", "str2 = %s\n", str2);
 }
 
 TEST(string_tests, strings_case_not_equal) {
 	ASSERT_CASE_STRNE(str1, "Hello123");
-	ASSERT_CASE_STRNE_INFO(str2, "World123", "str2 = %s\n", str2);
-
 	EXPECT_CASE_STRNE(str1, "hello123");
+}
+
+TEST(string_tests, strings_case_not_equal_info) {
+	ASSERT_CASE_STRNE_INFO(str2, "World123", "str2 = %s\n", str2);
 	EXPECT_CASE_STRNE_INFO(str2, "world123", "str2 = %s\n", str2);
 }


### PR DESCRIPTION
Add a new test executable `failing_tests` and use this to capture snapshots of error output