### PR TITLE
Use dynamic array to store test data

### DIFF
--- a/include/rktest/rktest.h
+++ b/include/rktest/rktest.h
@@ -31,14 +31,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // RK Test is a small unit test library for C99 with an interface heavily based
 // on Google Test, featuring self registering tests.
 
-/* Config variables --------------------------------------------------------- */
-// Define these variables before including rktest.h to configure the max number
-// of supported test suites and max number of unit tests per suite.
-
-#ifndef RKTEST_MAX_NUM_TEST_SUITES
-#define RKTEST_MAX_NUM_TEST_SUITES ((size_t)64)
-#endif
-
 /* Public API --------------------------------------------------------------- */
 int rktest_main(int argc, const char* argv[]);
 

--- a/include/rktest/rktest.h
+++ b/include/rktest/rktest.h
@@ -39,10 +39,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define RKTEST_MAX_NUM_TEST_SUITES ((size_t)64)
 #endif
 
-#ifndef RKTEST_MAX_NUM_TESTS_PER_SUITE
-#define RKTEST_MAX_NUM_TESTS_PER_SUITE ((size_t)64)
-#endif
-
 /* Public API --------------------------------------------------------------- */
 int rktest_main(int argc, const char* argv[]);
 

--- a/include/rktest/rktest.h
+++ b/include/rktest/rktest.h
@@ -199,6 +199,7 @@ typedef struct {
 	const char* suite_name;
 	const char* test_name;
 	void (*run)(void);
+	bool is_disabled;
 } rktest_test_t;
 
 /* Assertions */

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -46,54 +46,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma warning(disable: 4996) // needed for strncpy
 #endif
 
-/* -------------------------- Types and constants -------------------------- */
-#define RKTEST_MAX_NUM_TESTS (RKTEST_MAX_NUM_TEST_SUITES * RKTEST_MAX_NUM_TESTS_PER_SUITE)
-#define RKTEST_MAX_FILTER_LENGTH 256
-
-#define foreach(type_ptr, iter, array, array_len) \
-	for (type_ptr iter = &array[0]; iter != &array[array_len]; iter++)
-
-typedef enum {
-	RKTEST_ENABLE_VTERM_ERROR_INVALID_HANDLE_VALUE,
-	RKTEST_ENABLE_VTERM_ERROR_GET_CONSOLE_MODE_FAILED,
-	RKTEST_ENABLE_VTERM_ERROR_ENABLE_VIRTUAL_TERMINAL_FAILED,
-	RKTEST_ENABLE_VTERM_OK,
-} rktest_enable_vterm_result_t;
-
-typedef enum {
-	RKTEST_COLOR_MODE_ON,
-	RKTEST_COLOR_MODE_OFF,
-	RKTEST_COLOR_MODE_AUTO,
-} rktest_color_mode_t;
-
-typedef struct {
-	rktest_color_mode_t color_mode;
-	char test_filter[RKTEST_MAX_FILTER_LENGTH];
-	bool print_timestamps_enabled;
-} rktest_config_t;
-
-typedef struct {
-	const char* name;
-	rktest_test_t tests[RKTEST_MAX_NUM_TESTS_PER_SUITE];
-	bool test_is_disabled[RKTEST_MAX_NUM_TESTS_PER_SUITE];
-	size_t total_num_tests;
-	size_t num_disabled_tests;
-} rktest_suite_t;
-
-typedef struct {
-	rktest_suite_t test_suites[RKTEST_MAX_NUM_TEST_SUITES];
-	size_t num_test_suites;
-	size_t total_num_filtered_suites;
-	size_t total_num_filtered_tests;
-	size_t total_num_disabled_tests;
-} rktest_environment_t;
-
-typedef struct {
-	size_t num_passed_tests;
-	rktest_test_t failed_tests[RKTEST_MAX_NUM_TESTS];
-	size_t num_failed_tests;
-} rktest_report_t;
-
 /* ------------------------- Vector implementation ------------------------- */
 // Based on https://github.com/Warwolt/rkvec/blob/main/include/rkvec/rkvec.h
 // Which in turn is based on https://github.com/nothings/stb/blob/master/stb_ds.h
@@ -219,6 +171,54 @@ rktest_millis_t rktest_timer_stop(rktest_timer_t* timer) {
 	return ms;
 }
 #endif
+
+/* -------------------------- Types and constants -------------------------- */
+#define RKTEST_MAX_NUM_TESTS (RKTEST_MAX_NUM_TEST_SUITES * RKTEST_MAX_NUM_TESTS_PER_SUITE)
+#define RKTEST_MAX_FILTER_LENGTH 256
+
+#define foreach(type_ptr, iter, array, array_len) \
+	for (type_ptr iter = &array[0]; iter != &array[array_len]; iter++)
+
+typedef enum {
+	RKTEST_ENABLE_VTERM_ERROR_INVALID_HANDLE_VALUE,
+	RKTEST_ENABLE_VTERM_ERROR_GET_CONSOLE_MODE_FAILED,
+	RKTEST_ENABLE_VTERM_ERROR_ENABLE_VIRTUAL_TERMINAL_FAILED,
+	RKTEST_ENABLE_VTERM_OK,
+} rktest_enable_vterm_result_t;
+
+typedef enum {
+	RKTEST_COLOR_MODE_ON,
+	RKTEST_COLOR_MODE_OFF,
+	RKTEST_COLOR_MODE_AUTO,
+} rktest_color_mode_t;
+
+typedef struct {
+	rktest_color_mode_t color_mode;
+	char test_filter[RKTEST_MAX_FILTER_LENGTH];
+	bool print_timestamps_enabled;
+} rktest_config_t;
+
+typedef struct {
+	const char* name;
+	rktest_test_t tests[RKTEST_MAX_NUM_TESTS_PER_SUITE];
+	bool test_is_disabled[RKTEST_MAX_NUM_TESTS_PER_SUITE];
+	size_t total_num_tests;
+	size_t num_disabled_tests;
+} rktest_suite_t;
+
+typedef struct {
+	rktest_suite_t test_suites[RKTEST_MAX_NUM_TEST_SUITES];
+	size_t num_test_suites;
+	size_t total_num_filtered_suites;
+	size_t total_num_filtered_tests;
+	size_t total_num_disabled_tests;
+} rktest_environment_t;
+
+typedef struct {
+	size_t num_passed_tests;
+	rktest_test_t failed_tests[RKTEST_MAX_NUM_TESTS];
+	size_t num_failed_tests;
+} rktest_report_t;
 
 /* ---------------------------- String utility ----------------------------- */
 static bool string_starts_with(const char* str, const char* prefix) {

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -105,7 +105,7 @@ typedef struct {
 } rk_vector_header_t;
 
 #define vec_foreach(type_ptr, iter, vec) \
-	for (type_ptr iter = &vec[0]; iter != &vec[vec_len(vec)]; iter++)
+	for (type_ptr iter = &(vec)[0]; iter != &(vec)[vec_len(vec)]; iter++)
 
 #define vec_t(type) type*
 #define vec_new() NULL
@@ -637,8 +637,14 @@ static void print_failed_tests(rktest_report_t* report) {
 	printf(" %zu FAILED TEST%s\n", report->num_failed_tests, report->num_failed_tests > 1 ? "S" : "");
 }
 
-static void print_int_vec(const vec_t(int) int_vec) {
-	vec_foreach(const int*, num, int_vec) {
+static void push_int_vec(vec_t(int) * int_vec) {
+	vec_push(*int_vec, 12);
+	vec_push(*int_vec, 34);
+	vec_push(*int_vec, 56);
+}
+
+static void print_int_vec(const vec_t(int) * int_vec) {
+	vec_foreach(const int*, num, *int_vec) {
 		printf("num = %d\n", *num);
 	}
 }
@@ -681,10 +687,8 @@ int rktest_main(int argc, const char* argv[]) {
 	// CHECK
 	{
 		vec_t(int) int_vec = vec_new();
-		vec_push(int_vec, 12);
-		vec_push(int_vec, 34);
-		vec_push(int_vec, 56);
-		print_int_vec(int_vec);
+		push_int_vec(&int_vec);
+		print_int_vec(&int_vec);
 		vec_free(int_vec);
 	}
 

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -498,7 +498,9 @@ static rktest_environment_t setup_test_env(const rktest_config_t* config) {
 		/* Find or add test suite */
 		rktest_suite_t* suite = find_suite_with_name(env.test_suites, test.suite_name);
 		if (!suite) {
-			vec_push(env.test_suites, (rktest_suite_t) { 0, .name = test.suite_name });
+			rktest_suite_t new_suite = { 0 };
+			new_suite.name = test.suite_name;
+			vec_push(env.test_suites, new_suite);
 			suite = &vec_back(env.test_suites);
 		}
 

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -636,6 +636,14 @@ static void print_failed_tests(rktest_report_t* report) {
 	printf(" %zu FAILED TEST%s\n", report->num_failed_tests, report->num_failed_tests > 1 ? "S" : "");
 }
 
+static void free_report_env(rktest_report_t* report) {
+	free(report);
+}
+
+static void free_test_env(rktest_environment_t* env) {
+	free(env);
+}
+
 static void push_int_vec(vec_t(int) * int_vec) {
 	vec_push(*int_vec, 12);
 	vec_push(*int_vec, 34);
@@ -695,8 +703,8 @@ int rktest_main(int argc, const char* argv[]) {
 		vec_free(my_struct.int_vec);
 	}
 
-	free(report);
-	free(env);
+	free_report_env(report);
+	free_test_env(env);
 
 	return tests_failed;
 }

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -553,9 +553,8 @@ static bool run_test(const rktest_test_t* test, const rktest_config_t* config) {
 	return test_passed;
 }
 
-static rktest_report_t* run_all_tests(rktest_environment_t* env, const rktest_config_t* config) {
-	rktest_report_t* report = malloc(sizeof(rktest_report_t));
-	*report = (rktest_report_t) { 0 };
+static rktest_report_t run_all_tests(rktest_environment_t* env, const rktest_config_t* config) {
+	rktest_report_t report = { 0 };
 
 	vec_foreach(rktest_suite_t*, suite, env->test_suites) {
 		/* Skip suite if all cases filtered out */
@@ -576,9 +575,9 @@ static rktest_report_t* run_all_tests(rktest_environment_t* env, const rktest_co
 			/* Run non-disabled test */
 			const bool test_passed = run_test(test, config);
 			if (test_passed) {
-				report->num_passed_tests++;
+				report.num_passed_tests++;
 			} else {
-				vec_push(report->failed_tests, *test);
+				vec_push(report.failed_tests, *test);
 			}
 		}
 		rktest_millis_t suite_time_ms = rktest_timer_stop(&suite_timer);
@@ -603,7 +602,6 @@ static void print_failed_tests(rktest_report_t* report) {
 
 static void free_test_report(rktest_report_t* report) {
 	vec_free(report->failed_tests);
-	free(report);
 }
 
 static void free_test_env(rktest_environment_t* env) {
@@ -620,12 +618,11 @@ int rktest_main(int argc, const char* argv[]) {
 	if (*config.test_filter) {
 		rktest_printf_yellow("Note: Test filter = %s\n", config.test_filter);
 	}
-
 	rktest_log_info("[==========] ", "Running %zu tests from %zu test suites.\n", env.total_num_filtered_tests, env.total_num_filtered_suites);
 	rktest_log_info("[----------] ", "Global test environment set-up.\n");
 
 	rktest_timer_t total_time_timer = rktest_timer_start();
-	rktest_report_t* report = run_all_tests(&env, &config);
+	rktest_report_t report = run_all_tests(&env, &config);
 	rktest_millis_t total_time_ms = rktest_timer_stop(&total_time_timer);
 
 	rktest_log_info("[----------] ", "Global test environment tear-down.\n");
@@ -634,11 +631,11 @@ int rktest_main(int argc, const char* argv[]) {
 		printf("(%d ms total)", total_time_ms);
 	}
 	printf("\n");
-	rktest_log_info("[  PASSED  ] ", "%zu tests.\n", report->num_passed_tests);
+	rktest_log_info("[  PASSED  ] ", "%zu tests.\n", report.num_passed_tests);
 
-	const bool tests_failed = vec_len(report->failed_tests) > 0;
+	const bool tests_failed = vec_len(report.failed_tests) > 0;
 	if (tests_failed) {
-		print_failed_tests(report);
+		print_failed_tests(&report);
 	}
 
 	if (env.total_num_disabled_tests > 0) {
@@ -648,7 +645,7 @@ int rktest_main(int argc, const char* argv[]) {
 		rktest_printf_yellow("  YOU HAVE %zu DISABLED TEST%s\n", env.total_num_disabled_tests, env.total_num_disabled_tests > 1 ? "S" : "");
 	}
 
-	free_test_report(report);
+	free_test_report(&report);
 	free_test_env(&env);
 
 	return tests_failed;

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_failing_tests
   '''
-  [==========] Running 36 tests from 5 test suites.
+  [==========] Running 37 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -168,7 +168,7 @@
   [       OK ] string_tests.strings_case_not_equal_info 
   [----------] 8 tests from string_tests 
   
-  [----------] 7 tests from wildcard_match_tests
+  [----------] 8 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [       OK ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [ RUN      ] wildcard_match_tests.literal_pattern_matches_only_exact_literal 
@@ -183,11 +183,13 @@
   [       OK ] wildcard_match_tests.prefix_and_suffix_match 
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
-  [----------] 7 tests from wildcard_match_tests 
+  [ RUN      ] wildcard_match_tests.double_asterisk 
+  [       OK ] wildcard_match_tests.double_asterisk 
+  [----------] 8 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 36 tests from 5 test suites ran. 
-  [  PASSED  ] 15 tests.
+  [==========] 37 tests from 5 test suites ran. 
+  [  PASSED  ] 16 tests.
   [  FAILED  ] 21 tests, listed below:
   [  FAILED  ] float_tests.float_equal
   [  FAILED  ] float_tests.float_equal_info
@@ -213,13 +215,16 @@
   
    21 FAILED TESTS
     YOU HAVE 3 DISABLED TESTS
+  num = 12
+  num = 34
+  num = 56
   
   '''
 # ---
 # name: test_infix_match
   '''
   Note: Test filter = *tests*
-  [==========] Running 36 tests from 5 test suites.
+  [==========] Running 37 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -292,7 +297,7 @@
   [       OK ] string_tests.strings_case_not_equal_info 
   [----------] 8 tests from string_tests 
   
-  [----------] 7 tests from wildcard_match_tests
+  [----------] 8 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [       OK ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [ RUN      ] wildcard_match_tests.literal_pattern_matches_only_exact_literal 
@@ -307,19 +312,24 @@
   [       OK ] wildcard_match_tests.prefix_and_suffix_match 
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
-  [----------] 7 tests from wildcard_match_tests 
+  [ RUN      ] wildcard_match_tests.double_asterisk 
+  [       OK ] wildcard_match_tests.double_asterisk 
+  [----------] 8 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 36 tests from 5 test suites ran. 
-  [  PASSED  ] 36 tests.
+  [==========] 37 tests from 5 test suites ran. 
+  [  PASSED  ] 37 tests.
   
     YOU HAVE 3 DISABLED TESTS
+  num = 12
+  num = 34
+  num = 56
   
   '''
 # ---
 # name: test_no_args
   '''
-  [==========] Running 36 tests from 5 test suites.
+  [==========] Running 37 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -392,7 +402,7 @@
   [       OK ] string_tests.strings_case_not_equal_info 
   [----------] 8 tests from string_tests 
   
-  [----------] 7 tests from wildcard_match_tests
+  [----------] 8 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [       OK ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [ RUN      ] wildcard_match_tests.literal_pattern_matches_only_exact_literal 
@@ -407,13 +417,18 @@
   [       OK ] wildcard_match_tests.prefix_and_suffix_match 
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
-  [----------] 7 tests from wildcard_match_tests 
+  [ RUN      ] wildcard_match_tests.double_asterisk 
+  [       OK ] wildcard_match_tests.double_asterisk 
+  [----------] 8 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 36 tests from 5 test suites ran. 
-  [  PASSED  ] 36 tests.
+  [==========] 37 tests from 5 test suites ran. 
+  [  PASSED  ] 37 tests.
   
     YOU HAVE 3 DISABLED TESTS
+  num = 12
+  num = 34
+  num = 56
   
   '''
 # ---
@@ -460,6 +475,9 @@
   [----------] Global test environment tear-down.
   [==========] 16 tests from 1 test suites ran. 
   [  PASSED  ] 16 tests.
+  num = 12
+  num = 34
+  num = 56
   
   '''
 # ---
@@ -500,13 +518,16 @@
   [----------] Global test environment tear-down.
   [==========] 10 tests from 3 test suites ran. 
   [  PASSED  ] 10 tests.
+  num = 12
+  num = 34
+  num = 56
   
   '''
 # ---
 # name: test_wildcard_match
   '''
   Note: Test filter = *
-  [==========] Running 36 tests from 5 test suites.
+  [==========] Running 37 tests from 5 test suites.
   [----------] Global test environment set-up.
   [----------] 1 tests from disabled_tests
   [ DISABLED ] disabled_tests.DISABLED_this_test_should_not_run
@@ -579,7 +600,7 @@
   [       OK ] string_tests.strings_case_not_equal_info 
   [----------] 8 tests from string_tests 
   
-  [----------] 7 tests from wildcard_match_tests
+  [----------] 8 tests from wildcard_match_tests
   [ RUN      ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [       OK ] wildcard_match_tests.empty_pattern_matches_only_empty_string 
   [ RUN      ] wildcard_match_tests.literal_pattern_matches_only_exact_literal 
@@ -594,13 +615,18 @@
   [       OK ] wildcard_match_tests.prefix_and_suffix_match 
   [ RUN      ] wildcard_match_tests.infix_match 
   [       OK ] wildcard_match_tests.infix_match 
-  [----------] 7 tests from wildcard_match_tests 
+  [ RUN      ] wildcard_match_tests.double_asterisk 
+  [       OK ] wildcard_match_tests.double_asterisk 
+  [----------] 8 tests from wildcard_match_tests 
   
   [----------] Global test environment tear-down.
-  [==========] 36 tests from 5 test suites ran. 
-  [  PASSED  ] 36 tests.
+  [==========] 37 tests from 5 test suites ran. 
+  [  PASSED  ] 37 tests.
   
     YOU HAVE 3 DISABLED TESTS
+  num = 12
+  num = 34
+  num = 56
   
   '''
 # ---

--- a/tests/__snapshots__/snapshot_test.ambr
+++ b/tests/__snapshots__/snapshot_test.ambr
@@ -215,9 +215,6 @@
   
    21 FAILED TESTS
     YOU HAVE 3 DISABLED TESTS
-  num = 12
-  num = 34
-  num = 56
   
   '''
 # ---
@@ -321,9 +318,6 @@
   [  PASSED  ] 37 tests.
   
     YOU HAVE 3 DISABLED TESTS
-  num = 12
-  num = 34
-  num = 56
   
   '''
 # ---
@@ -426,9 +420,6 @@
   [  PASSED  ] 37 tests.
   
     YOU HAVE 3 DISABLED TESTS
-  num = 12
-  num = 34
-  num = 56
   
   '''
 # ---
@@ -475,9 +466,6 @@
   [----------] Global test environment tear-down.
   [==========] 16 tests from 1 test suites ran. 
   [  PASSED  ] 16 tests.
-  num = 12
-  num = 34
-  num = 56
   
   '''
 # ---
@@ -518,9 +506,6 @@
   [----------] Global test environment tear-down.
   [==========] 10 tests from 3 test suites ran. 
   [  PASSED  ] 10 tests.
-  num = 12
-  num = 34
-  num = 56
   
   '''
 # ---
@@ -624,9 +609,6 @@
   [  PASSED  ] 37 tests.
   
     YOU HAVE 3 DISABLED TESTS
-  num = 12
-  num = 34
-  num = 56
   
   '''
 # ---

--- a/tests/wildcard_match_tests.c
+++ b/tests/wildcard_match_tests.c
@@ -70,3 +70,7 @@ TEST(wildcard_match_tests, prefix_and_suffix_match) {
 TEST(wildcard_match_tests, infix_match) {
 	EXPECT_TRUE(string_wildcard_match("wildcard_match_tests.empty_pattern_matches_only_empty_string", "*tests*"));
 }
+
+TEST(wildcard_match_tests, double_asterisk) {
+	EXPECT_TRUE(string_wildcard_match("strawberry", "straw**berry"));
+}


### PR DESCRIPTION
Replace the fixed size arrays and their configuration constants with dynamic array, so that any number of tests can be supported with the same built library.