### PR TITLE
Remove rktest_main.c in favor of ifdef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(CheckCCompilerFlag)
 option(rktest_build_tests "Build rktest tests" OFF)
 option(rktest_build_samples "Build rktest samples" OFF)
 
+set(RKTEST "rktest")
 set(RKTEST_MAIN "rktest_main")
 
 if(MSVC)
@@ -15,14 +16,19 @@ else()
 endif()
 
 # Test Library
-add_library(${RKTEST_MAIN}
-    src/rktest.c
-)
+add_library(${RKTEST} src/rktest.c)
+add_library(${RKTEST_MAIN} src/rktest.c)
+
+target_compile_definitions(${RKTEST_MAIN} PRIVATE RKTEST_DEFINE_MAIN=1)
+
+set_property(TARGET ${RKTEST} PROPERTY C_STANDARD 99)
 set_property(TARGET ${RKTEST_MAIN} PROPERTY C_STANDARD 99)
-target_include_directories(${RKTEST_MAIN} PUBLIC
-    include
-)
+
+target_include_directories(${RKTEST} PUBLIC include)
+target_include_directories(${RKTEST_MAIN} PUBLIC include)
+
 if(UNIX)
+    target_link_libraries(${RKTEST} PUBLIC m)
     target_link_libraries(${RKTEST_MAIN} PUBLIC m)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CheckCCompilerFlag)
 option(rktest_build_tests "Build rktest tests" OFF)
 option(rktest_build_samples "Build rktest samples" OFF)
 
-set(RKTEST "rktest")
+set(RKTEST_MAIN "rktest_main")
 
 if(MSVC)
     add_compile_options(/W4 /WX)
@@ -15,16 +15,15 @@ else()
 endif()
 
 # Test Library
-add_library(${RKTEST}
-    src/rktest_main.c
+add_library(${RKTEST_MAIN}
     src/rktest.c
 )
-set_property(TARGET ${RKTEST} PROPERTY C_STANDARD 99)
-target_include_directories(${RKTEST} PUBLIC
+set_property(TARGET ${RKTEST_MAIN} PROPERTY C_STANDARD 99)
+target_include_directories(${RKTEST_MAIN} PUBLIC
     include
 )
 if(UNIX)
-    target_link_libraries(${RKTEST} PUBLIC m)
+    target_link_libraries(${RKTEST_MAIN} PUBLIC m)
 endif()
 
 # Tests
@@ -39,11 +38,11 @@ if (rktest_build_tests)
     # Passing tests
     add_executable(tests ${TEST_SRC})
     target_include_directories(tests PUBLIC include)
-    target_link_libraries(tests PUBLIC ${RKTEST})
+    target_link_libraries(tests PUBLIC ${RKTEST_MAIN})
     # Failing tests
     add_executable(failing_tests ${TEST_SRC})
     target_include_directories(failing_tests PUBLIC include)
-    target_link_libraries(failing_tests PUBLIC ${RKTEST})
+    target_link_libraries(failing_tests PUBLIC ${RKTEST_MAIN})
     target_compile_definitions(failing_tests PRIVATE RKTEST_FAILING_TESTS=1)
 endif (rktest_build_tests)
 
@@ -51,5 +50,5 @@ endif (rktest_build_tests)
 if (rktest_build_samples)
     add_executable(sample1 samples/sample01_factorial.c)
     target_include_directories(sample1 PUBLIC include)
-    target_link_libraries(sample1 PUBLIC ${RKTEST})
+    target_link_libraries(sample1 PUBLIC ${RKTEST_MAIN})
 endif (rktest_build_samples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ include(CheckCCompilerFlag)
 option(rktest_build_tests "Build rktest tests" OFF)
 option(rktest_build_samples "Build rktest samples" OFF)
 
+set(RKTEST "rktest")
+
 if(MSVC)
     add_compile_options(/W4 /WX)
 else()
@@ -13,16 +15,16 @@ else()
 endif()
 
 # Test Library
-add_library(${PROJECT_NAME}
+add_library(${RKTEST}
     src/rktest_main.c
     src/rktest.c
 )
-set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)
-target_include_directories(${PROJECT_NAME} PUBLIC
+set_property(TARGET ${RKTEST} PROPERTY C_STANDARD 99)
+target_include_directories(${RKTEST} PUBLIC
     include
 )
 if(UNIX)
-    target_link_libraries(${PROJECT_NAME} PUBLIC m)
+    target_link_libraries(${RKTEST} PUBLIC m)
 endif()
 
 # Tests
@@ -37,11 +39,11 @@ if (rktest_build_tests)
     # Passing tests
     add_executable(tests ${TEST_SRC})
     target_include_directories(tests PUBLIC include)
-    target_link_libraries(tests PUBLIC ${PROJECT_NAME})
+    target_link_libraries(tests PUBLIC ${RKTEST})
     # Failing tests
     add_executable(failing_tests ${TEST_SRC})
     target_include_directories(failing_tests PUBLIC include)
-    target_link_libraries(failing_tests PUBLIC ${PROJECT_NAME})
+    target_link_libraries(failing_tests PUBLIC ${RKTEST})
     target_compile_definitions(failing_tests PRIVATE RKTEST_FAILING_TESTS=1)
 endif (rktest_build_tests)
 
@@ -49,5 +51,5 @@ endif (rktest_build_tests)
 if (rktest_build_samples)
     add_executable(sample1 samples/sample01_factorial.c)
     target_include_directories(sample1 PUBLIC include)
-    target_link_libraries(sample1 PUBLIC ${PROJECT_NAME})
+    target_link_libraries(sample1 PUBLIC ${RKTEST})
 endif (rktest_build_samples)

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -671,6 +671,8 @@ int rktest_main(int argc, const char* argv[]) {
 	return tests_failed;
 }
 
+#ifdef RKTEST_DEFINE_MAIN
 int main(int argc, const char* argv[]) {
 	return rktest_main(argc, argv);
 }
+#endif

--- a/src/rktest.c
+++ b/src/rktest.c
@@ -670,3 +670,7 @@ int rktest_main(int argc, const char* argv[]) {
 
 	return tests_failed;
 }
+
+int main(int argc, const char* argv[]) {
+	return rktest_main(argc, argv);
+}

--- a/src/rktest_main.c
+++ b/src/rktest_main.c
@@ -1,7 +1,0 @@
-#include "rktest/rktest.h"
-
-#include <stdio.h>
-
-int main(int argc, const char* argv[]) {
-	return rktest_main(argc, argv);
-}


### PR DESCRIPTION
Moves the `main` function into `rktest.c`, and uses a define `RKTEST_DEFINE_MAIN` to control if main function is included in library. 

Update CMakeLists.txt to build both `rktest` and `rktest_main` libraries