### PR TITLE
Make sure filter_pattern can fit in test_filter

### DIFF
--- a/include/rktest/rktest.h
+++ b/include/rktest/rktest.h
@@ -921,12 +921,29 @@ static rktest_config_t parse_args(int argc, const char* argv[]) {
 		else if (string_starts_with(arg, "--rktest_filter=")) {
 			const char* filter_pattern = arg + strlen("--rktest_filter=");
 			const size_t filter_len = strlen(filter_pattern);
-			if (filter_len > RKTEST_MAX_FILTER_LENGTH) {
-				fprintf(stderr, "Error: filter pattern too long. Max length is (%d)", RKTEST_MAX_FILTER_LENGTH);
+			const size_t max_filter_len = RKTEST_MAX_FILTER_LENGTH - 1;
+			if (filter_len > max_filter_len) {
+				fprintf(stderr, "Error: filter pattern too long. Max length is (%lu)", max_filter_len);
 				fprintf(stderr, "filter pattern = \"%s\"", filter_pattern);
 				exit(1);
 			}
-			strncpy(config.test_filter, filter_pattern, filter_len);
+			// strncpy will copy all bytes up to a NULL in the source or until it
+			// reaches the size in the third param.
+			//
+			// This means it will not add a NULL to the end of the destination if the
+			// source does not have one.
+			//
+			// Examples from the strncpy man page are useful,
+			//
+			// strncpy(buf, "1", 5);       // { '1',  0,   0,   0,   0  }
+			// strncpy(buf, "1234", 5);    // { '1', '2', '3', '4',  0  }
+			// strncpy(buf, "12345", 5);   // { '1', '2', '3', '4', '5' }
+			// strncpy(buf, "123456", 5);  // { '1', '2', '3', '4', '5' }
+			//
+			// So if test_filter is a char[256], then max_filter_len will be 255 and if
+			// filter_pattern is also 255, then it will have one character left which
+			// strncpy will make a NULL.
+			strncpy(config.test_filter, filter_pattern, max_filter_len);
 		}
 
 		else if (string_starts_with(arg, "--rktest_print_time=")) {


### PR DESCRIPTION
Discovered an issue while compiling with `cmake -DCMAKE_BUILD_TYPE=Release`,

```
In function ‘strncpy’,
    inlined from ‘parse_args’ at /rktest/include/rktest/rktest.h:929:4,
    inlined from ‘initialize’ at /rktest/include/rktest/rktest.h:981:27,
/rktest/include/rktest/rktest.h:1188:27:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: error: ‘__builtin___strncpy_chk’ specified bound depends on the length of the source argument [-Werror=stringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
```

The third parameter was being determined by the length on the source, which is what this error is complaining about.  Since `strncpy` will copy up to the first NULL byte in the source, copying to the destination size is safer, and I think expected by `strncpy`.

This also means we should only copy up to one less than the destination size since `strncpy` won't NULL-terminate the destination for us if the source doesn't have one.  I handle this by adding a local variable that is one less than `RKTEST_MAX_FILTER_LENGTH`.