### PR TITLE
Detect support for nextafterf in RKTest

### DIFF
--- a/include/rktest/nextafterf.h
+++ b/include/rktest/nextafterf.h
@@ -1,0 +1,103 @@
+// This file includes code from the musl project.
+
+/*
+musl as a whole is licensed under the following standard MIT license:
+
+----------------------------------------------------------------------
+Copyright © 2005-2020 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+*/
+
+#include <math.h>
+#include <stdint.h>
+
+/* fp_force_eval ensures that the input value is computed when that's
+   otherwise unused.  To prevent the constant folding of the input
+   expression, an additional fp_barrier may be needed or a compilation
+   mode that does so (e.g. -frounding-math in gcc). Then it can be
+   used to evaluate an expression for its fenv side-effects only.   */
+
+#ifndef fp_force_evalf
+#define fp_force_evalf fp_force_evalf
+static inline void fp_force_evalf(float x) {
+	volatile float y;
+	y = x;
+}
+#endif
+
+#ifndef fp_force_eval
+#define fp_force_eval fp_force_eval
+static inline void fp_force_eval(double x) {
+	volatile double y;
+	y = x;
+}
+#endif
+
+#ifndef fp_force_evall
+#define fp_force_evall fp_force_evall
+static inline void fp_force_evall(long double x) {
+	volatile long double y;
+	y = x;
+}
+#endif
+
+#define FORCE_EVAL(x)                             \
+	do {                                          \
+		if (sizeof(x) == sizeof(float)) {         \
+			fp_force_evalf(x);                    \
+		} else if (sizeof(x) == sizeof(double)) { \
+			fp_force_eval(x);                     \
+		} else {                                  \
+			fp_force_evall(x);                    \
+		}                                         \
+	} while (0)
+
+static float nextafterf(float x, float y) {
+	union {
+		float f;
+		uint32_t i;
+	} ux = { x }, uy = { y };
+	uint32_t ax, ay, e;
+
+	if (isnan(x) || isnan(y))
+		return x + y;
+	if (ux.i == uy.i)
+		return y;
+	ax = ux.i & 0x7fffffff;
+	ay = uy.i & 0x7fffffff;
+	if (ax == 0) {
+		if (ay == 0)
+			return y;
+		ux.i = (uy.i & 0x80000000) | 1;
+	} else if (ax > ay || ((ux.i ^ uy.i) & 0x80000000))
+		ux.i--;
+	else
+		ux.i++;
+	e = ux.i & 0x7f800000;
+	/* raise overflow if ux.f is infinite and x is finite */
+	if (e == 0x7f800000)
+		FORCE_EVAL(x + x);
+	/* raise underflow if ux.f is subnormal or zero */
+	if (e == 0)
+		FORCE_EVAL(x * x + ux.f * ux.f);
+	return ux.f;
+}

--- a/include/rktest/rktest.h
+++ b/include/rktest/rktest.h
@@ -553,6 +553,11 @@ bool rktest_filenames_enabled(void);
 #include <ctype.h>
 #include <float.h>
 #include <math.h>
+
+#if _POSIX_C_SOURCE < 200112L
+#include "nextafterf.h"
+#endif
+
 #include <memory.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
As described in the nextafterf(3) man page for glibc, we check for the POSIX version and then provide our own definition of nextafterf if glibc does not.